### PR TITLE
Fix crash during midi instrument patchname undo.

### DIFF
--- a/common/undo_patchname.c
+++ b/common/undo_patchname.c
@@ -18,6 +18,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
 
 #include "nsmtracker.h"
+#include "instruments_proc.h"
 #include "undo.h"
 #include "OS_Player_proc.h"
 
@@ -103,8 +104,10 @@ static void *Undo_Do_PatchName(
   patch->name_is_edited = undo_ae->name_is_edited;
   patch->forward_events = undo_ae->forward_events;
 
-  GFX_update_instrument_widget(patch);
-  CHIP_update(patch->patchdata);
+  if (patch->instrument == get_audio_instrument()) {
+    GFX_update_instrument_widget(patch);
+    CHIP_update(patch->patchdata);
+  }
 
   undo_ae->name = new_name;
   undo_ae->name_is_edited = new_name_is_edited;


### PR DESCRIPTION

Recipe:

a) New MIDI Instrument

b) Change patchname
    "Calling Undo patchname. Old name: Unnamed. New name: John Doe"

c) Undo && Crash

Program received signal SIGSEGV, Segmentation fault.
PLUGIN_get_effect_value (plugin=0x3c4ae00, effect_num=0, where=VALUE_FROM_STORAGE)
    at audio/SoundPlugin.c:922
922       float store_value = safe_float_read(&plugin->savable_effect_values[effect_num]);

(gdb) print plugin->savable_effect_values
$1 = (float *) 0x0

(gdb) bt
#0  PLUGIN_get_effect_value (plugin=0x3c4ae00, effect_num=0, where=VALUE_FROM_STORAGE)
    at audio/SoundPlugin.c:922
#1  0x000000000077a268 in CHIP_update (plugin=0x3c4ae00) at mixergui/QM_chip.cpp:383
#2  0x00000000005e2c0b in Undo_Do_PatchName (window=<optimized out>, wblock=<optimized out>, 
    wtrack=<optimized out>, realline=<optimized out>, pointer=0x69e98e0)
    at common/undo_patchname.c:107
#3  0x00000000005e0eb7 in Undo () at common/undo.c:484
[...]
