### PR TITLE
Fix VECTOR_clean and VECTOR_move.

### DIFF
--- a/common/vector.c
+++ b/common/vector.c
@@ -35,7 +35,8 @@ void VECTOR_reverse(vector_t *v){
 vector_t *VECTOR_move(vector_t *from){
   vector_t *to = talloc(sizeof(vector_t));
 
-  to->elements               = from->elements;
+  to->elements = talloc(from->num_elements_allocated*sizeof(void*));
+  memcpy(to->elements, from->elements, from->num_elements*sizeof(void*));
   to->num_elements_allocated = from->num_elements_allocated;
   to->num_elements           = from->num_elements;
 
@@ -72,8 +73,8 @@ void VECTOR_copy_elements(vector_t *from, int from_pos, int num_elements_to_copy
 }
 
 void VECTOR_clean(vector_t *v){
-  v->num_elements = 0;
   memset(v->elements,0,v->num_elements*sizeof(void*)); // cleaned since we use a GC
+  v->num_elements = 0;
 }
 
 vector_t *VECTOR_append(vector_t *v1, vector_t *v2){


### PR DESCRIPTION
bug-1: memset was unused in VECTOR_clean (bug-2 bypassed).

bug-2: if "from" and "to" in VECTOR_move share the elements, "to"
continues to have num_elements but the elements are NULL after (the
fixed) VECTOR_clean (there is at least a segfault in `get_notenum'
OpenGL/Render.cpp:1039 when trs is NULL; for example, apply the change
only for VECTOR_clean and try to load blowfish song).
