### PR TITLE
Add LLVM 3.8.1+ compat to bundled faust

### DIFF
--- a/bin/packages/faust2/Makefile
+++ b/bin/packages/faust2/Makefile
@@ -108,7 +108,7 @@ clean :
 	$(MAKE) -C compiler -f $(MAKEFILE) clean
 	$(MAKE) -C examples clean
 	$(MAKE) -C architecture/osclib clean
-	$(MAKE) -C architecture/httpdlib/src clean
+#	$(MAKE) -C architecture/httpdlib/src clean
 	$(MAKE) -C embedded/faustremote/RemoteServer clean
 	$(MAKE) -C embedded/faustremote clean
 	$(MAKE) -C tools/sound2faust clean

--- a/bin/packages/faust2/architecture/scheduler.cpp
+++ b/bin/packages/faust2/architecture/scheduler.cpp
@@ -642,7 +642,7 @@ static INLINE int Range(int min, int max, int val)
     }
 }
 
-#if defined(LLVM_36) || defined(LLVM_35) || defined(LLVM_34) || defined(LLVM_33) || defined(LLVM_32) || defined(LLVM_31)
+#if defined(LLVM_40) || defined(LLVM_39) || defined(LLVM_38) || defined(LLVM_37) || defined(LLVM_36) || defined(LLVM_35) || defined(LLVM_34) || defined(LLVM_33) || defined(LLVM_32) || defined(LLVM_31)
     extern "C" void computeThreadExternal(void* dsp, int num_thread) __attribute__((weak_import));
 #else
     void computeThreadExternal(void* dsp, int num_thread);

--- a/bin/packages/faust2/benchmark/Makefile
+++ b/bin/packages/faust2/benchmark/Makefile
@@ -48,10 +48,22 @@ CXX = /opt/local/libexec/llvm-3.7/bin/clang++
 LLC = /opt/local/libexec/llvm-3.7/bin/llc
 endif
 
-ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.8.0))
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.8.0 3.8.1))
 LLVM_VERSION  = LLVM_38
 CXX = /opt/local/libexec/llvm-3.8/bin/clang++
 LLC = /opt/local/libexec/llvm-3.8/bin/llc
+endif
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.9.0 3.9.1))
+LLVM_VERSION  = LLVM_39
+CXX = /opt/local/libexec/llvm-3.9/bin/clang++
+LLC = /opt/local/libexec/llvm-3.9/bin/llc
+endif
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0))
+LLVM_VERSION  = LLVM_40
+CXX = /opt/local/libexec/llvm-4.0/bin/clang++
+LLC = /opt/local/libexec/llvm-4.0/bin/llc
 endif
 
 ifeq ($(system), Darwin)

--- a/bin/packages/faust2/compiler/Makefile.unix
+++ b/bin/packages/faust2/compiler/Makefile.unix
@@ -107,6 +107,16 @@ else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.8.0 3.8.1))
     CLANGLIBS=$(CLANGLIBSLIST)
     CXXFLAGS += -std=gnu++11
 
+else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.9.0 3.9.1))
+    LLVM_VERSION = LLVM_39
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11
+
+else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0))
+    LLVM_VERSION = LLVM_40
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11
+
 else
     $(error "Unknown LLVM version $(LLVM_VERSION)")
 

--- a/bin/packages/faust2/compiler/generator/llvm/clang_code_container.cpp
+++ b/bin/packages/faust2/compiler/generator/llvm/clang_code_container.cpp
@@ -35,7 +35,7 @@
 #include <clang/Frontend/TextDiagnosticPrinter.h>
 
 #include <llvm/Bitcode/ReaderWriter.h>
-#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 #include <llvm/IR/Module.h>
 #else
 #include <llvm/Module.h>
@@ -45,7 +45,7 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 #include <llvm/Support/FileSystem.h>
 #define sysfs_binary_flag sys::fs::F_None
 #elif defined(LLVM_34)
@@ -102,7 +102,7 @@ LLVMResult* ClangCodeContainer::produceModule(Tree signals, const string& filena
     fCompiler->compileMultiSignal(signals);
     fContainer->produceClass();
     
-#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     // Compile it with 'clang'
     IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts = new DiagnosticOptions();
     TextDiagnosticPrinter* DiagClient = new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.cpp
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.cpp
@@ -48,11 +48,11 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
     fResult->fModule->setDataLayout("e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128");
     fBuilder = new IRBuilder<>(getContext());
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38))    
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
     // Set "-fast-math"
     FastMathFlags FMF;
     FMF.setUnsafeAlgebra();
-#if defined(LLVM_38)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     fBuilder->setFastMathFlags(FMF);
 #else
     fBuilder->SetFastMathFlags(FMF);
@@ -75,11 +75,11 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
     fResult = result;
     fBuilder = new IRBuilder<>(getContext());
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38))    
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
     // Set "-fast-math"
     FastMathFlags FMF;
     FMF.setUnsafeAlgebra();
-#if defined(LLVM_38)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     fBuilder->setFastMathFlags(FMF);
 #else
     fBuilder->SetFastMathFlags(FMF);
@@ -196,7 +196,7 @@ void LLVMCodeContainer::generateComputeBegin(const string& counter)
     Function* llvm_compute = Function::Create(llvm_compute_type, GlobalValue::ExternalLinkage, "compute" + fKlassName, fResult->fModule);
     llvm_compute->setCallingConv(CallingConv::C);
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     llvm_compute->setDoesNotAlias(3U);
     llvm_compute->setDoesNotAlias(4U);
 #elif defined(LLVM_32) 
@@ -266,7 +266,7 @@ void LLVMCodeContainer::generateGetSampleRate(int field_index)
 
     BasicBlock* block = BasicBlock::Create(getContext(), "entry_block", sr_fun);
     fBuilder->SetInsertPoint(block);
-#if defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
 #else
     Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -509,7 +509,7 @@ void LLVMCodeContainer::generateMetadata(llvm::PointerType* meta_type_ptr)
 
         Value* idx2[3];
         idx2[0] = load_meta_ptr;
-    #if defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         idx2[1] = fBuilder->CreateConstGEP2_32(type_def1, llvm_label1, 0, 0);
         idx2[2] = fBuilder->CreateConstGEP2_32(type_def2, llvm_label2, 0, 0);
     #else
@@ -991,7 +991,7 @@ void LLVMWorkStealingCodeContainer::generateComputeThreadExternal()
 
     Function* llvm_computethreadInternal = fResult->fModule->getFunction("computeThread");
     assert(llvm_computethreadInternal);
-#if defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     Value* fun_args[] = { fBuilder->CreateBitCast(arg1, fStruct_DSP_ptr), arg2 };
     CallInst* call_inst = fBuilder->CreateCall(llvm_computethreadInternal, fun_args);
 #else

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
@@ -28,7 +28,7 @@
 #include "omp_code_container.hh"
 #include "wss_code_container.hh"
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/Support/FileSystem.h>
     #define sysfs_binary_flag sys::fs::F_None
 #elif defined(LLVM_34)
@@ -37,7 +37,7 @@
     #define sysfs_binary_flag raw_fd_ostream::F_Binary
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define STREAM_ERROR std::error_code
 #else
     #define STREAM_ERROR std::string

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -42,13 +42,20 @@
 #include "exception.hh"
 #include "rn_base64.h"
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <system_error>
 #else
     #include <llvm/Support/system_error.h>
 #endif
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_40)
+    #include <llvm/Bitcode/BitcodeWriter.h>
+    #include <llvm/Bitcode/BitcodeReader.h>
+#elif defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39)
+    #include <llvm/Bitcode/ReaderWriter.h>
+#endif
+
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/Module.h>
     #include <llvm/IR/LLVMContext.h>
     #include <llvm/IRReader/IRReader.h>
@@ -56,7 +63,6 @@
     #include <llvm/Support/FormattedStream.h>
     #include <llvm/Support/SourceMgr.h>
     #include <llvm/Support/MemoryBuffer.h>
-    #include <llvm/Bitcode/ReaderWriter.h>
     #include <llvm/ADT/Triple.h>
     #include <llvm/Support/TargetRegistry.h>
     #include <llvm-c/Core.h>
@@ -66,7 +72,7 @@
     #include <llvm/Support/IRReader.h>
 #endif
 
-#if defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/Analysis/TargetLibraryInfo.h>
     #include <llvm/Analysis/TargetTransformInfo.h>
     #include <llvm/IR/PassManager.h>
@@ -86,19 +92,19 @@
  */
 #if defined(LLVM_32)
     #include <llvm/DataLayout.h>
-#elif !defined(LLVM_33) && !defined(LLVM_34) && !defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38)
+#elif !defined(LLVM_33) && !defined(LLVM_34) && !defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
     #ifndef _WIN32
         #include <llvm/Target/TargetData.h>
     #endif
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/ExecutionEngine/MCJIT.h>
 #else
     #include <llvm/ExecutionEngine/JIT.h>
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/Verifier.h>
 #else
     #include <llvm/Analysis/Verifier.h>
@@ -108,7 +114,7 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/LegacyPassNameParser.h>
     #include <llvm/Linker/Linker.h>
 #else
@@ -119,7 +125,7 @@
 #include <llvm/Support/Host.h>
 #include <llvm/Support/ManagedStatic.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/IRPrintingPasses.h>
     #define llvmcreatePrintModulePass(out) createPrintModulePass(out)
 #else
@@ -130,17 +136,17 @@
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Support/Threading.h>
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     #include "llvm/ExecutionEngine/ObjectCache.h"
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define OwningPtr std::unique_ptr
 #endif
 
 #include <llvm/Support/TargetSelect.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/Support/FileSystem.h>
     #define sysfs_binary_flag sys::fs::F_None
 #elif defined(LLVM_34)
@@ -149,13 +155,13 @@
     #define sysfs_binary_flag raw_fd_ostream::F_Binary
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define GET_CPU_NAME llvm::sys::getHostCPUName().str()
 #else
     #define GET_CPU_NAME llvm::sys::getHostCPUName()
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define STREAM_ERROR std::error_code
     #define MEMORY_BUFFER MemoryBufferRef
     #define MEMORY_BUFFER_GET(buffer) (buffer.getBuffer())
@@ -169,7 +175,7 @@
     #define MEMORY_BUFFER_CREATE(stringref) (MemoryBuffer::getMemBuffer(stringref))
 #endif
 
-#if defined(LLVM_34) || defined(LLVM_35)  || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_34) || defined(LLVM_35)  || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define MAX_OPT_LEVEL 5
 #else 
     #define MAX_OPT_LEVEL 4
@@ -264,7 +270,7 @@ class FaustObjectCache : public ObjectCache {
 };
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 
 // Workaround for iOS compiled LLVM 3.6 missing symbol
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
@@ -318,7 +324,7 @@ static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
 }
 #endif
 
-#if defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
                                 LLVMContext& Context,
                                 string* ErrMsg)
@@ -336,7 +342,7 @@ static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
 
 void* llvm_dsp_factory::loadOptimize(const string& function)
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     void* fun = (void*)fJIT->getFunctionAddress(function);
     if (fun) {
         return fun;
@@ -416,7 +422,7 @@ void llvm_dsp_factory::writeDSPFactoryToIRFile(const string& ir_code_path)
 
 bool llvm_dsp_factory::crossCompile(const std::string& target)
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     delete fObjectCache;
     fObjectCache = new FaustObjectCache();
     setTarget(target);
@@ -429,7 +435,7 @@ bool llvm_dsp_factory::crossCompile(const std::string& target)
 
 std::string llvm_dsp_factory::writeDSPFactoryToMachineAux(const std::string& target)
 { 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     if (target == "" || target == getTarget()) {
         return fObjectCache->getMachineCode();
     } else {
@@ -460,7 +466,7 @@ void llvm_dsp_factory::writeDSPFactoryToMachineFile(const std::string& machine_c
     out.flush();
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
 llvm_dsp_factory::llvm_dsp_factory(const string& sha_key, const string& machine_code, const string& target)
 {
     init("MachineDSP", "");
@@ -487,12 +493,12 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key, Module* module, LLVMCo
     fResult->fModule = module;
     fResult->fContext = context;
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     fObjectCache = NULL;
 #endif
 }
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 void llvm_dsp_factory::LLVMFatalErrorHandler(const char* reason)
 {
     throw faustexception(reason);
@@ -512,10 +518,10 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key,
     if (llvm_dsp_factory::gInstance++ == 0) {
         
         // Install a LLVM error handler
-    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         LLVMInstallFatalErrorHandler(llvm_dsp_factory::LLVMFatalErrorHandler);
     #endif
-    #if (!defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38)) // In LLVM 3.5 this is gone.
+    #if (!defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)) // In LLVM 3.5 this is gone.
         if (!llvm_start_multithreaded()) {
             printf("llvm_start_multithreaded error...\n");
         }
@@ -527,7 +533,7 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key,
     fExpandedDSP = expanded_dsp_content;
     fSHAKey = sha_key;
     fTarget = (target == "") ? fTarget = (llvm::sys::getDefaultTargetTriple() + ":" + GET_CPU_NAME) : target;  
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     fObjectCache = NULL;
 #endif
     
@@ -581,7 +587,7 @@ int llvm_dsp_factory::getOptlevel()
     return -1;
 }
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 /// AddOptimizationPasses - This routine adds optimization passes
 /// based on selected optimization level, OptLevel. This routine
 /// duplicates llvm-gcc behaviour.
@@ -644,22 +650,22 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
     InitializeNativeTargetAsmParser();
     
     // For ObjectCache to work...
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     LLVMLinkInMCJIT();
 #endif
     
     // Restoring from machine code
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     if (fObjectCache) {
     
         // JIT
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         EngineBuilder builder(unique_ptr<Module>(fResult->fModule));
     #else
         EngineBuilder builder(fResult->fModule);
     #endif
         builder.setEngineKind(EngineKind::JIT);
-    #if !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38)
+    #if !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
         builder.setUseMCJIT(true);
     #endif
         TargetMachine* tm = builder.selectTarget();
@@ -684,7 +690,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         initializeVectorization(Registry);
         initializeIPO(Registry);
         initializeAnalysis(Registry);
-#if !defined(LLVM_38)
+#if !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
         initializeIPA(Registry);
 #endif
         initializeTransformUtils(Registry);
@@ -692,7 +698,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         initializeInstrumentation(Registry);
         initializeTarget(Registry);
        
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         EngineBuilder builder(unique_ptr<Module>(fResult->fModule));
     #else
         EngineBuilder builder(fResult->fModule);
@@ -707,7 +713,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         // MCJIT does not work correctly (incorrect float numbers ?) when used with dynamic libLLVM
     #if (defined(LLVM_34) || defined(LLVM_35)) && !defined(_MSC_VER)
         builder.setUseMCJIT(true);
-    #elif !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38)
+    #elif !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
         builder.setUseMCJIT(false);
     #endif
     
@@ -763,7 +769,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             PASS_MANAGER pm;
             FUNCTION_PASS_MANAGER fpm(fResult->fModule);
             
-        #if defined(LLVM_37) || defined(LLVM_38) // Code taken from opt.cpp
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) // Code taken from opt.cpp
             TargetLibraryInfoImpl TLII(Triple(fResult->fModule->getTargetTriple()));
             pm.add(new TargetLibraryInfoWrapperPass(TLII));
         #else
@@ -772,7 +778,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             pm.add(tli);
         #endif
 
-        #if defined(LLVM_38)
+        #if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             fResult->fModule->setDataLayout(fJIT->getDataLayout());
         #elif defined(LLVM_37) // Code taken from opt.cpp
             fResult->fModule->setDataLayout(*fJIT->getDataLayout());
@@ -786,7 +792,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         #endif
           
             // Add internal analysis passes from the target machine (mandatory for vectorization to work)
-        #if defined(LLVM_37) || defined(LLVM_38) // Code taken from opt.cpp
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) // Code taken from opt.cpp
             pm.add(createTargetTransformInfoWrapperPass(tm->getTargetIRAnalysis()));
         #else
             tm->addAnalysisPasses(pm);
@@ -810,7 +816,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             pm.add(createVerifierPass());
             
             if ((debug_var != "") && (debug_var.find("FAUST_LLVM4") != string::npos)) {
-            #if defined(LLVM_37) || defined(LLVM_38)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
                 // TODO
             #else
                 tm->addPassesToEmitFile(pm, fouts(), TargetMachine::CGFT_AssemblyFile, true);
@@ -825,7 +831,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             }
         }
         
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
         fObjectCache = new FaustObjectCache();
         fJIT->setObjectCache(fObjectCache);
     }
@@ -974,7 +980,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
 
 llvm_dsp_factory::~llvm_dsp_factory()
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     delete fObjectCache;
 #endif
     if (fJIT) {
@@ -989,10 +995,10 @@ llvm_dsp_factory::~llvm_dsp_factory()
     }
     
     if (--llvm_dsp_factory::gInstance == 0) {
-#if  (!defined(LLVM_35)) && (!defined(LLVM_36)) && (!defined(LLVM_37)) && (!defined(LLVM_38)) // In LLVM 3.5 this is gone.
+#if  (!defined(LLVM_35)) && (!defined(LLVM_36)) && (!defined(LLVM_37)) && (!defined(LLVM_38)) && !(defined(LLVM_39)) && !(defined(LLVM_40)) // In LLVM 3.5 this is gone.
         llvm_stop_multithreaded();
     #endif
-    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         LLVMResetFatalErrorHandler();
     #endif
     }
@@ -1094,7 +1100,7 @@ EXPORT std::string getLibFaustVersion() { return FAUSTVERSION; }
 EXPORT Module* load_single_module(const string filename, LLVMContext* context)
 {
     SMDiagnostic err;
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     Module* module = parseIRFile(filename, err, *context).get();
 #else
     Module* module = ParseIRFile(filename, err, *context);
@@ -1112,7 +1118,7 @@ EXPORT bool link_modules(Module* dst, Module* src, char* error_msg)
 {
     bool res = false;
 
-#if defined(LLVM_38)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     if (Linker::linkModules(*dst, std::unique_ptr<Module>(src))) { // Don't know what I'm doing here. Could Linker::linkModules try to free the src pointer? -Kjetil
         snprintf(error_msg, 256, "cannot link module");
         
@@ -1412,7 +1418,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromBitcodeFile(const string& bit_code_pa
 {
     TLock lock(gDSPFactoriesLock);
   
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(bit_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromBitcodeFile failed : %s\n", ec.message().c_str());
@@ -1456,7 +1462,7 @@ static llvm_dsp_factory* readDSPFactoryFromIRAux(MEMORY_BUFFER buffer, const str
         setlocale(LC_ALL, "C");
         LLVMContext* context = new LLVMContext();
         SMDiagnostic err;
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         Module* module = parseIR(buffer, err, *context).get();  // ParseIR takes ownership of the given buffer, so don't delete it
     #else
         Module* module = ParseIR(buffer, err, *context);        // ParseIR takes ownership of the given buffer, so don't delete it
@@ -1493,7 +1499,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromIRFile(const string& ir_code_path, co
 {
     TLock lock(gDSPFactoriesLock);
  
- #if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+ #if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(ir_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromIRFile failed : %s\n", ec.message().c_str());
@@ -1521,7 +1527,7 @@ EXPORT void writeDSPFactoryToIRFile(llvm_dsp_factory* factory, const string& ir_
     }
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
     
 static llvm_dsp_factory* readDSPFactoryFromMachineAux(MEMORY_BUFFER buffer, const std::string& target)
 {
@@ -1565,7 +1571,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromMachineFile(const std::string& machin
 {
     TLock lock(gDSPFactoriesLock);
     
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(machine_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromMachineFile failed : %s\n", ec.message().c_str());
@@ -1859,7 +1865,7 @@ EXPORT void writeCDSPFactoryToIRFile(llvm_dsp_factory* factory, const char* ir_c
     }
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
 EXPORT llvm_dsp_factory* readCDSPFactoryFromMachine(const char* machine_code, const char* target)
 {
     return readDSPFactoryFromMachine(machine_code, target);

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.hh
@@ -67,7 +67,7 @@ class llvm_dsp_factory : public smartable {
     
         ExecutionEngine* fJIT;
 
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
         FaustObjectCache* fObjectCache;
     #endif
         LLVMResult* fResult;
@@ -104,7 +104,7 @@ class llvm_dsp_factory : public smartable {
         
         bool crossCompile(const std::string& target);
       
-    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         static void LLVMFatalErrorHandler(const char* reason);
     #endif
     
@@ -120,7 +120,7 @@ class llvm_dsp_factory : public smartable {
               
         llvm_dsp_factory(const string& sha_key, Module* module, LLVMContext* context, const string& target, int opt_level = 0);
         
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)) && !defined(_MSC_VER)
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER) 
         llvm_dsp_factory(const string& sha_key, const string& machine_code, const string& target);
     #endif
       

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_instructions.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_instructions.hh
@@ -22,13 +22,6 @@
 #ifndef _LLVM_INSTRUCTIONS_H
 #define _LLVM_INSTRUCTIONS_H
 
-/**********************************************************************
-
-		Historique :
-		-----------
-
-***********************************************************************/
-
 using namespace std;
 
 #include <string>
@@ -41,7 +34,7 @@ using namespace std;
 #include "exception.hh"
 #include "global.hh"
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/DerivedTypes.h>
     #include <llvm/IR/LLVMContext.h>
     #include <llvm/IR/Module.h>
@@ -51,7 +44,7 @@ using namespace std;
     #include <llvm/Module.h>
 #endif
 
-#if defined(LLVM_38)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #define GET_ITERATOR(it) &(*(it))
 #else
     #define GET_ITERATOR(it) it
@@ -59,13 +52,13 @@ using namespace std;
 
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/ExecutionEngine/MCJIT.h>
 #else
     #include <llvm/ExecutionEngine/JIT.h>
 #endif
 
-#if defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/PassManager.h>
 #else
     #include <llvm/PassManager.h>
@@ -73,17 +66,24 @@ using namespace std;
 
 #include <llvm/Transforms/Scalar.h>
 #include <llvm-c/BitWriter.h>
-#include <llvm/Bitcode/ReaderWriter.h>
+
+#if defined(LLVM_40)
+    #include <llvm/Bitcode/BitcodeWriter.h>
+    #include <llvm/Bitcode/BitcodeReader.h>
+#else
+    #include <llvm/Bitcode/ReaderWriter.h>
+#endif
+
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Host.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/Verifier.h>
 #else
     #include <llvm/Analysis/Verifier.h>
 #endif
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/IRBuilder.h>
 #elif defined(LLVM_32) 
     #include <llvm/IRBuilder.h>
@@ -92,7 +92,7 @@ using namespace std;
     #include <llvm/Support/IRBuilder.h>
 #endif
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
     #include <llvm/IR/DataLayout.h>
 #endif
 
@@ -291,7 +291,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
         VECTOR_OF_TYPES fDSPFields;
         int fDSPFieldsCounter;
         string fPrefix;
-    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
         DataLayout* fDataLayout;
     #endif
 
@@ -395,7 +395,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
             // llvm_create_dsp block
             BasicBlock* entry_func_llvm_create_dsp = BasicBlock::Create(fModule->getContext(), "entry", func_llvm_create_dsp);
 
-        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             CallInst* call_inst1 = CallInst::Create(func_malloc, genInt64(fModule, fDataLayout->getTypeSizeInBits(dsp_type)), "", entry_func_llvm_create_dsp);
         #else
             // Dynamically computed object size (see http://nondot.org/sabre/LLVMNotes/SizeOf-OffsetOf-VariableSizedStructs.txt)
@@ -583,7 +583,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
             initTypes(module);
         #if defined(LLVM_35) || defined(LLVM_36)
             fDataLayout = new DataLayout(*module->getDataLayout());
-        #elif defined(LLVM_34)  || defined(LLVM_37) || defined(LLVM_38)
+        #elif defined(LLVM_34)  || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             fDataLayout = new DataLayout(module->getDataLayout());
         #endif
         }
@@ -592,7 +592,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
         {
             // External object not covered by Garbageable, so delete it here
             delete fBuilder;
-        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             delete fDataLayout;
         #endif
         }
@@ -979,7 +979,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             GlobalVariable* llvm_key = addStringConstant(inst->fKey, type_def1);
             GlobalVariable* llvm_value = addStringConstant(inst->fValue, type_def2);
 
-         #if defined(LLVM_37) || defined(LLVM_38)
+         #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* const_string1 = fBuilder->CreateConstGEP2_32(type_def1, llvm_key, 0, 0);
             Value* const_string2 = fBuilder->CreateConstGEP2_32(type_def2, llvm_value, 0, 0);
          #else
@@ -993,7 +993,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 zone_ptr = Constant::getNullValue((itfloat() == Typed::kFloat) ? fTypeMap[Typed::kFloat_ptr] : fTypeMap[Typed::kDouble_ptr]);
             } else {
                 int field_index = fDSPFieldsNames[inst->fZone];
-            #if defined(LLVM_37) || defined(LLVM_38)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
                 zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
             #else
                 zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1021,7 +1021,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(inst->fName);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_name = addStringConstant(inst->fName, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_name, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_name, 0, 0);
@@ -1043,7 +1043,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             idx[1] = mth_index;
             Value* mth_ptr = fBuilder->CreateInBoundsGEP(ui, MAKE_IXD(idx, idx+2));
             LoadInst* mth = fBuilder->CreateLoad(mth_ptr);
-        #if defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* fun_args[] = { fUIInterface_ptr, const_string };
             CallInst* call_inst = fBuilder->CreateCall(mth, fun_args);
         #else
@@ -1080,7 +1080,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1094,7 +1094,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
             Value* fun_args[] = { fUIInterface_ptr, const_string, zone_ptr };
             CallInst* call_inst = fBuilder->CreateCall(mth, fun_args);
@@ -1131,7 +1131,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1144,7 +1144,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
         #else
             Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1191,7 +1191,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1205,7 +1205,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
         #else
             Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1352,7 +1352,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 function = Function::Create(fun_type, (inst->fType->fAttribute & FunTyped::kLocal) ? GlobalValue::InternalLinkage : GlobalValue::ExternalLinkage, inst->fName, fModule);
                 function->setCallingConv(CallingConv::C);
                 
-            #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+            #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
                 // In order for auto-vectorization to correctly work with vectorizable math functions
                 if (find(gMathLibTable.begin(), gMathLibTable.end(), inst->fName) != gMathLibTable.end()) {
                     function->setDoesNotAccessMemory();
@@ -1473,7 +1473,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
         {
             if (named_address->fAccess & Address::kStruct) {
                 int field_index = fDSPFieldsNames[named_address->fName];
-            #if defined(LLVM_37) || defined(LLVM_38)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
                 return fBuilder->CreateStructGEP(0, getDSP(), field_index);
             #else
                 return fBuilder->CreateStructGEP(getDSP(), field_index);
@@ -1645,7 +1645,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 
             if (named_address->fAccess & Address::kStruct) {
                 int field_index = fDSPFieldsNames[named_address->fName];
-            #if defined(LLVM_37) || defined(LLVM_38)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
                 Value* store_ptr = fBuilder->CreateStructGEP(0, getDSP(), field_index);
             #else
                 Value* store_ptr = fBuilder->CreateStructGEP(getDSP(), field_index);
@@ -2319,7 +2319,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 // Inst result for comparison
                 return generateScalarSelect(opcode, comp_value, genInt32(fModule, 1, size), genInt32(fModule, 0, size), size);
             } else {
-            #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38))
+            #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
                 LlvmValue value = fBuilder->CreateBinOp((Instruction::BinaryOps)gBinOpTable[opcode]->fLlvmFloatInst, arg1, arg2);
                 Instruction* inst = cast<Instruction>(value);
                 inst->setMetadata(LLVMContext::MD_fpmath, fBuilder->getDefaultFPMathTag());

--- a/bin/packages/faust2/compiler/signals/binop.cpp
+++ b/bin/packages/faust2/compiler/signals/binop.cpp
@@ -32,7 +32,7 @@ static bool noNtrl(const Node& n) { return falsePredicate(n); }
 
 #if LLVM_BUILD
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
 #include <llvm/IR/Instructions.h>
 #else
 #include <llvm/Instructions.h>

--- a/bin/packages/faust2/compiler/tlib/compatibility.hh
+++ b/bin/packages/faust2/compiler/tlib/compatibility.hh
@@ -22,7 +22,7 @@
 #ifndef __COMPATIBILITY__
 #define __COMPATIBILITY__
  
-#define LLVM_BUILD (LLVM_31 || LLVM_32 || LLVM_33 || LLVM_34 || LLVM_35 || LLVM_36 || LLVM_37 || LLVM_38)
+#define LLVM_BUILD (LLVM_31 || LLVM_32 || LLVM_33 || LLVM_34 || LLVM_35 || LLVM_36 || LLVM_37 || LLVM_38 || LLVM_39 || LLVM_40)
 
 unsigned faust_alarm(unsigned seconds);
 

--- a/bin/packages/faust2/examples/Makefile.llvmcompile
+++ b/bin/packages/faust2/examples/Makefile.llvmcompile
@@ -42,9 +42,19 @@ LLVM_VERSION  = LLVM_37
 LLVM_PREFIX = /opt/local/libexec/llvm-3.7/bin
 endif
 
-ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.8.0))
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.8.0 3.8.1))
 LLVM_VERSION  = LLVM_38
 LLVM_PREFIX = /opt/local/libexec/llvm-3.8/bin
+endif
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 3.9.0 3.9.1))
+LLVM_VERSION  = LLVM_39
+LLVM_PREFIX = /opt/local/libexec/llvm-3.9/bin
+endif
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0))
+LLVM_VERSION  = LLVM_40
+LLVM_PREFIX = /opt/local/libexec/llvm-4.0/bin
 endif
 
 CLANG = $(LLVM_PREFIX)/clang++


### PR DESCRIPTION
This commit now makes it able to compile faust bundled with radium
on LLVM 3.8.1, 3.9.0, 3.9.1 and 4.0

4.0 compilation is untested, see upstream:
https://github.com/grame-cncm/faust/commit/1d564b400eee9a4743318d316f4811cf1890d696
