### PR TITLE
Suppress GCC6 indentation warnings

### DIFF
--- a/Makefile.Qt
+++ b/Makefile.Qt
@@ -81,7 +81,7 @@ S7OPTS ?=
 
 WHICHFAUST = $(shell pwd)/bin/packages/faust2/compiler/faust
 # The include files in audio/faudiostream are copied from Faust 0.9.55.
-FAUST = $(WHICHFAUST) -Wno-misleading-indentation -I $(shell pwd)/bin/packages/faust2/architecture  #`which faust` #/usr/bin/faust #~/site/bin/faust
+FAUST = $(WHICHFAUST) -Wno-error=misleading-indentation -I $(shell pwd)/bin/packages/faust2/architecture  #`which faust` #/usr/bin/faust #~/site/bin/faust
 
 LLVM_OPTS ?=
 
@@ -220,7 +220,7 @@ endif
 # -Wunused-parameter
 
 # OPT is C flags
-OPT=$(COMMONOPT) -Wstrict-prototypes -Wno-misleading-indentation -std=gnu99
+OPT=$(COMMONOPT) -Wstrict-prototypes -Wno-error=misleading-indentation -std=gnu99
 # -D_FORTIFY_SOURCE=2 -O2
 
 CPUOPT ?=
@@ -233,7 +233,7 @@ endif
 # -pg
 
 # CPPOPT is CPP flags
-CPPOPT = $(COMMONOPT) -Wno-unused-function -Wno-misleading-indentation -std=gnu++11 -DNDEBUG # NDEBUG must be defined to avoid runtime checks in Visualization Library. assert() is not used in radium, so it shouldnt be a problem.
+CPPOPT = $(COMMONOPT) -Wno-unused-function -Wno-error=misleading-indentation -std=gnu++11 -DNDEBUG # NDEBUG must be defined to avoid runtime checks in Visualization Library. assert() is not used in radium, so it shouldnt be a problem.
 
 # Can't be enabled because of 3rd party header files:
 #-Wsuggest-override

--- a/Makefile.Qt
+++ b/Makefile.Qt
@@ -81,7 +81,7 @@ S7OPTS ?=
 
 WHICHFAUST = $(shell pwd)/bin/packages/faust2/compiler/faust
 # The include files in audio/faudiostream are copied from Faust 0.9.55.
-FAUST = $(WHICHFAUST) -I $(shell pwd)/bin/packages/faust2/architecture  #`which faust` #/usr/bin/faust #~/site/bin/faust
+FAUST = $(WHICHFAUST) -Wno-misleading-indentation -I $(shell pwd)/bin/packages/faust2/architecture  #`which faust` #/usr/bin/faust #~/site/bin/faust
 
 LLVM_OPTS ?=
 
@@ -220,7 +220,7 @@ endif
 # -Wunused-parameter
 
 # OPT is C flags
-OPT=$(COMMONOPT) -Wstrict-prototypes -std=gnu99
+OPT=$(COMMONOPT) -Wstrict-prototypes -Wno-misleading-indentation -std=gnu99
 # -D_FORTIFY_SOURCE=2 -O2
 
 CPUOPT ?=
@@ -233,7 +233,7 @@ endif
 # -pg
 
 # CPPOPT is CPP flags
-CPPOPT = $(COMMONOPT) -Wno-unused-function -std=gnu++11 -DNDEBUG # NDEBUG must be defined to avoid runtime checks in Visualization Library. assert() is not used in radium, so it shouldnt be a problem.
+CPPOPT = $(COMMONOPT) -Wno-unused-function -Wno-misleading-indentation -std=gnu++11 -DNDEBUG # NDEBUG must be defined to avoid runtime checks in Visualization Library. assert() is not used in radium, so it shouldnt be a problem.
 
 # Can't be enabled because of 3rd party header files:
 #-Wsuggest-override

--- a/bin/packages/build.sh
+++ b/bin/packages/build.sh
@@ -9,7 +9,7 @@ unset CPPFLAGS
 unset LDFLAGS
 unset CXXFLAGS
 
-export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -fPIC"
+export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -Wno-misleading-indentation -fPIC"
 export CPPFLAGS="-mtune=generic -msse2 -mfpmath=sse -fPIC"
 export CXXFLAGS="-mtune=generic -msse2 -mfpmath=sse -fPIC"
 
@@ -148,7 +148,7 @@ cd ..
 
 
 # faust, debug
-export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -O0 -fsanitize=address -g -fPIC"
+export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -O0 -fsanitize=address -g -Wno-misleading-indentation -fPIC"
 export CPPFLAGS="-mtune=generic -msse2 -mfpmath=sse -O0 -fsanitize=address -g -fPIC"
 export CXXFLAGS="-mtune=generic -msse2 -mfpmath=sse -O0 -fsanitize=address -g -fPIC"
 export LDFLAGS="-fsanitize=address"
@@ -159,7 +159,7 @@ make clean
 cd ..
 
 #faust, release
-export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -O2 -g -fPIC"
+export CFLAGS="-mtune=generic -msse2 -mfpmath=sse -O2 -g -Wno-misleading-indentation -fPIC"
 export CPPFLAGS="-mtune=generic -msse2 -mfpmath=sse -O2 -g -fPIC"
 export CXXFLAGS="-mtune=generic -msse2 -mfpmath=sse -O2 -g -fPIC"
 export LDFLAGS=""


### PR DESCRIPTION
I found the source of my hit and miss compile issues. (like #894 and #901)

GCC6 introduces new warnings, which trigger on some older/unported packages.
(Mainly faust packages/audio and Visualisation lib)

This happens because of the compile flags used on them.
-Wall enables all warnings and -Werror treats them as errors
as -Wmisleading-indentation is a new warning in gcc6, _sloppy_ indentation blocks compiling.
See https://gcc.gnu.org/gcc-6/porting_to.html https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

This commit suppresses that particular warning.

Indent warnings still appear on visualisation lib, but since -Werror is not set on that makefile, it compires, so I left it be as it's tarball'd.