### PR TITLE
Add mimetype support for .rad files

### DIFF
--- a/bin/radium-mimetype.xml
+++ b/bin/radium-mimetype.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	<mime-type type="application/x-radium-rad">
+		<comment>Radium song file</comment>
+		<glob pattern="*.rad"/>
+	</mime-type>
+	<!-- Only .rad supported via xdg-open
+	<mime-type type="application/x-radium-mmd">
+		<comment>Med MoDule v2.1</comment>
+		<glob pattern="*.mmd"/>
+	</mime-type>
+	<mime-type type="application/x-radium-mmd2">
+		<comment>Med MoDule Pro</comment>
+		<glob pattern="*.mmd2"/>
+	</mime-type>
+	<mime-type type="application/x-radium-mmd3">
+		<comment>Med MoDule Pro v5</comment>
+		<glob pattern="*.mmd3"/>
+	</mime-type>
+	<mime-type type="application/x-radium-mod">
+		<comment>Amiga Module</comment>
+		<glob pattern="*.mod"/>
+	</mime-type>
+	<mime-type type="application/x-radium-xm">
+		<comment>Extended Module</comment>
+		<glob pattern="*.xm"/>
+	</mime-type>
+	-->
+</mime-info>
+

--- a/bin/radium.desktop
+++ b/bin/radium.desktop
@@ -2,10 +2,13 @@
 Encoding=UTF-8
 Type=Application
 Name=Radium
-GenericName=Music editor
+GenericName=Music tracker
 Comment=A graphical music editor. A next generation tracker.
-Exec=radium
+Exec=radium %f
 Icon=radium
 Terminal=false
 StartupNotify=false
-Categories=Audio;AudioVideo;AudioEditing;Qt;
+Categories=Audio;AudioVideo;AudioVideoEditing;Qt;Midi;Sequencer;Music;
+MimeType=application/x-radium-rad;
+# Only .rad file(s) via argument supported
+#MimeType=application/x-radium-rad;application/x-radium-mmd;application/x-radium-mmd2;application/x-radium-mmd3;application/x-radium-mod;application/x-radium-xm;audio/x-midi;


### PR DESCRIPTION
This commit takes advantage of argument support added in c8b3b64
You may now integrate radium-mimetype.xml and radium.desktop to

/usr/share/mime/packages & /usr/share/applications or similar
should do the trick for users' packaging or manual install needs.

e.g if you click a .rad file in a gui file browser, it should open
the .rad file directly in radium as long as you set it up correctly
and update the mime/desktop caches.