### PR TITLE
Make the vsync startup warning hidable

### DIFF
--- a/OpenGL/Widget.cpp
+++ b/OpenGL/Widget.cpp
@@ -1741,9 +1741,20 @@ QWidget *GL_create_widget(QWidget *parent){
   }
 
   if (GL_get_vsync()==false){
-    GFX_Message(NULL, "Warning: VSync disabled. You probably don't want to do that. You can enable vsync under\nEdit -> Preferences -> OpenGL -> Vertical Blank");
+	if (SETTINGS_read_bool("show_vsync_warning_during_startup", true)) {
+	  vector_t v = {};
+	  VECTOR_push_back(&v,"Ok");
+	  VECTOR_push_back(&v,"Don't show this message again");
+
+	  int result = GFX_Message(&v, "Warning: VSync disabled. You probably don't want to do that. You can enable vsync under\nEdit -> Preferences -> OpenGL -> Vertical Blank");
+
+	  if (result==1)
+		  SETTINGS_write_bool("show_vsync_warning_during_startup", false);
+
+	  GL_set_pause_rendering_on_off(true);
+    }
   }
-  
+
   if (is_opengl_certainly_too_old_questionmark()){
     GFX_Message(NULL,
                 "Your version of OpenGL is too old. Radium can not run.\n"

--- a/OpenGL/Widget.cpp
+++ b/OpenGL/Widget.cpp
@@ -1744,14 +1744,16 @@ QWidget *GL_create_widget(QWidget *parent){
 	if (SETTINGS_read_bool("show_vsync_warning_during_startup", true)) {
 	  vector_t v = {};
 	  VECTOR_push_back(&v,"Ok");
-	  VECTOR_push_back(&v,"Don't show this message again");
+	  int vsync_hide = VECTOR_push_back(&v,"Don't show this message again");
 
-	  int result = GFX_Message(&v, "Warning: VSync disabled. You probably don't want to do that. You can enable vsync under\nEdit -> Preferences -> OpenGL -> Vertical Blank");
-
-	  if (result==1)
+	  int vsyncret = GFX_Message(&v,
+			  "Warning: VSync is disabled. You probably don't want to do that. You can enable vsync under"
+			  "<p>"
+			  "Edit -> Preferences -> OpenGL -> Vertical Blank -> VSync"
+			  "<p>"
+			  "Please only consider turning vsync in radium off if your drivers are misbehaving. There is little performance gain compared to eg. Video Games and so disabling vsync option is provided for compability reasons.");
+	  if (vsyncret==vsync_hide)
 		  SETTINGS_write_bool("show_vsync_warning_during_startup", false);
-
-	  GL_set_pause_rendering_on_off(true);
     }
   }
 


### PR DESCRIPTION
Since 5b51eb3 the vsync warning is set to always show up during startup
if vsync is turned off.

This is problematic with Intel/AMD drivers on linux, when using TearFree
(on in radeon driver by default, not sure about Intel)

This commit adds a button for the user to be able to suppress this warning.