### PR TITLE
shure -> sure

### DIFF
--- a/amiga/Amiga_main.c
+++ b/amiga/Amiga_main.c
@@ -413,7 +413,7 @@ newprogram:
 
 #ifndef NOPLAYER
 		if( ! pc->isplaying){	// Don't want to do this while playing.
-			if(lastStuffTime + 1200 < conductor->cdt_ClockTime){		// Make shure it is at least one second since last time.
+			if(lastStuffTime + 1200 < conductor->cdt_ClockTime){		// Make sure it is at least one second since last time.
 //				debug("alloc and unalloc\n");
 /*
 				while( ((SetSignal(0L,0L)) & waitsig) == 0L){

--- a/amiga/plug-ins/camd_fx.c
+++ b/amiga/plug-ins/camd_fx.c
@@ -368,7 +368,7 @@ int CAMDgetFX(struct Tracker_Windows *window,struct Tracks *track,struct FX *fx)
 		}
 		camd_fx=&CAMD_fxs[selection];
 
-		menutitle="FX allready used";
+		menutitle="FX already used";
 
 		if(camd_fx->cc==-1) continue;
 

--- a/common/clipboard_localzooms.c
+++ b/common/clipboard_localzooms.c
@@ -56,7 +56,7 @@ struct LocalZooms *CB_CopyLocalZooms(
 	struct LocalZooms *tolocalzoom=NULL;
 	struct LocalZooms *localzoom=wblock->localzooms;
 
-	if(localzoom->level>0){			//Might be that we are trying to pack an allready packed localzoom-tree.
+	if(localzoom->level>0){			//Might be that we are trying to pack an already packed localzoom-tree.
 		CB_CopyLocalZoomsRec(&tolocalzoom,localzoom);
 		return tolocalzoom;
 	}

--- a/common/clipboard_range.c
+++ b/common/clipboard_range.c
@@ -128,7 +128,7 @@ void CancelRange_CurrPos(struct Tracker_Windows *window){
 
 /********************************************************
   FUNCTION
-    Makes shure that the range is legal. Must be
+    Makes sure that the range is legal. Must be
     called after shrinking the number of reallines
     in a wblock, or the number of tracks.
 ********************************************************/

--- a/common/disk_load.c
+++ b/common/disk_load.c
@@ -238,7 +238,7 @@ static bool Load_CurrPos_org(struct Tracker_Windows *window, const wchar_t *file
 
 	PlayStop();
 
-        if(Undo_are_you_shure_questionmark()==false)
+        if(Undo_are_you_sure_questionmark()==false)
           goto exit;
 
         if(filename==NULL)

--- a/common/disk_save.c
+++ b/common/disk_save.c
@@ -106,7 +106,7 @@ void SaveAs(struct Root *theroot){
 			ret=GFX_GetString(
 				theroot->song->tracker_windows,
 				NULL,
-				"File allready exists, are you shure? (yes/no)"
+				"File already exists, are you sure? (yes/no)"
 			);
 		}
 		if(!strcmp("no",ret)) return;

--- a/common/eventreciever.c
+++ b/common/eventreciever.c
@@ -53,7 +53,7 @@ bool Quit(struct Tracker_Windows *window){
 
 	printf("Going to quit\n");
 
-        return Undo_are_you_shure_questionmark();
+        return Undo_are_you_sure_questionmark();
 }
 
 

--- a/common/eventreciever_bu.c
+++ b/common/eventreciever_bu.c
@@ -89,7 +89,7 @@ bool Quit(struct Tracker_Windows *window){
 	if(num_undos>0){
 		sprintf(
 			temp,
-			"%s%d change%s has been made to file.\nAre you shure? (yes/no) >"
+			"%s%d change%s has been made to file.\nAre you sure? (yes/no) >"
 			,num_undos>=max_num_undos-1?"At least":"",
 			num_undos,
 			num_undos>1?"s":""

--- a/common/fxlines_legalize.c
+++ b/common/fxlines_legalize.c
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
 /****************************************************
   FUNCTION
-    Make shure that:
+    Make sure that:
 
     -No fxnodeline is placed on the same position
      as the start (or before) of the end of the note

--- a/common/gfx_subtrack.c
+++ b/common/gfx_subtrack.c
@@ -322,7 +322,7 @@ int GetNoteX2(const struct WTracks *wtrack, const struct Notes *note){
 
 /************************************************************************
   FUNCTION
-    Make shure that x is placed within the boundaries of the subtrack.
+    Make sure that x is placed within the boundaries of the subtrack.
 ************************************************************************/
 /*
 int SubtrackBoundaries(const struct WTracks *wtrack,int subtrack,int x){

--- a/common/list.c
+++ b/common/list.c
@@ -453,7 +453,7 @@ struct ListHeader3 *ListMoveElement3_FromNum_ns(
 
 /*****************************************************************************
   FUNCTION
-    Adds an element only if the list doesn't allready contain an element
+    Adds an element only if the list doesn't already contain an element
     with the same placement attributes.
 ******************************************************************************/
 int ListAddElement3_ns(

--- a/common/memory_bu.c
+++ b/common/memory_bu.c
@@ -118,7 +118,7 @@ void tfree(void *element){
 
 /*******************************************************************
   This function is called from gc.lib to allocate memory.
-  It uses amigaOS's own AllocMem to allocate to be shure
+  It uses amigaOS's own AllocMem to allocate to be sure
   to get the right type. (checking the result of calloc
   could allso have been done, but size is often near 1MB
   in size, and sas/c doesn't free memory before the next

--- a/common/notes_legalize.c
+++ b/common/notes_legalize.c
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
 /****************************************************
   FUNCTION
-    Make shure that:
+    Make sure that:
 
     -No end-note is placed before or on the start of the
      note or below the last legal position.

--- a/common/placement.c
+++ b/common/placement.c
@@ -73,7 +73,7 @@ void PlaceCopy(Place *p1,  Place *p2){
 */
 /************************************************************
   FUNCTION
-    Make shure that countor is not bigger or equal to dividor
+    Make sure that countor is not bigger or equal to dividor
     and that dividor is not bigger than MAX_UINT32.
 ************************************************************/
 void PlaceHandleOverflow(Place *p){
@@ -168,7 +168,7 @@ void PlaceSub(Place *p1,  const Place *p2){
 
 
 
-/* I'm not too shure if the next two routines ever should be used.
+/* I'm not too sure if the next two routines ever should be used.
    Handling overflow in these cases are maybe impossible. 
    They have never been tested either, and they have never been
    used anywhere. I guess the best solution for this

--- a/common/reallines.c
+++ b/common/reallines.c
@@ -84,7 +84,7 @@ void UpdateReallinesDependens(
   FUNCTION
     Returns the localzoom element that has its 'uplevel' attribute
     pointing to the first element in a localzoom list that the 'realline'
-    belongs to. Returns NULL if it is allready placed at level 0.
+    belongs to. Returns NULL if it is already placed at level 0.
 
   NOTES
     'realline' allso gets the realline value for the new position

--- a/common/temponodes_legalize.c
+++ b/common/temponodes_legalize.c
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
 /*****************************************************
   FUNCTION
-    Make shure that:
+    Make sure that:
 
     -That there are at least two temponodes
 

--- a/common/undo.c
+++ b/common/undo.c
@@ -166,7 +166,7 @@ void ResetUndo(void){
   update_gfx();
 }
 
-bool Undo_are_you_shure_questionmark(void){
+bool Undo_are_you_sure_questionmark(void){
   int num_undos = Undo_num_undos_since_last_save();
 
   if(num_undos>0){
@@ -175,7 +175,7 @@ bool Undo_are_you_shure_questionmark(void){
 
     sprintf(
             temp,
-            "%d change%s been made to file since song was saved.\nAre you shure? (yes/no) >",
+            "%d change%s been made to file since song was saved.\nAre you sure? (yes/no) >",
             num_undos,
             num_undos>1 ? "s have" : " has"
             );

--- a/common/undo.h
+++ b/common/undo.h
@@ -101,7 +101,7 @@ extern void Undo_New(
 #endif
 
 extern LANGSPEC void ResetUndo(void);
-extern LANGSPEC bool Undo_are_you_shure_questionmark(void);
+extern LANGSPEC bool Undo_are_you_sure_questionmark(void);
 extern LANGSPEC void Undo(void);
 extern LANGSPEC void Redo(void);
 extern LANGSPEC void SetMaxUndos(struct Tracker_Windows *window);

--- a/common/velocities.cpp
+++ b/common/velocities.cpp
@@ -117,7 +117,7 @@ static struct Velocities *add_velocity(
   velocity->velocity=R_BOUNDARIES(0,velocityvelocity,MAX_VELOCITY);
   
   /* ListAddElement3_ns returns -1 (and doesnt do anything else)
-     if there allready is an element with the same placement. */
+     if there already is an element with the same placement. */
 
   PLAYER_lock();{
     *pos = ListAddElement3_ns(&note->velocities,&velocity->l);

--- a/unused_files/PEQ_calc.c
+++ b/unused_files/PEQ_calc.c
@@ -134,7 +134,7 @@ STime PEQ_CalcNextEvent_old(
 	}
 
 	// Adding one in here is a quick way to avoid problems with rounding errors.
-	// The solution might be /to/ quick... I'm not shure. Seems to work well for now:
+	// The solution might be /to/ quick... I'm not sure. Seems to work well for now:
 	// (Doesn't allways work very well (no that was an overflow problem))
 
 	timesubtime1=time-time1;

--- a/unused_files/trackreallines.c
+++ b/unused_files/trackreallines.c
@@ -600,7 +600,7 @@ static void AddTrackReallineNote(
 
 /*** NOTES ****************************************************************
     About the following two procedures: There might be bugs here! I'm not
-    at all too shure if they allways function correct.
+    at all too sure if they allways function correct.
 ***************************************************************************/
 int FindNumberOfNotesOnTrackRealline(struct TrackReallineElements *element){
 	int ret=0;


### PR DESCRIPTION
Just a `find . -type f -exec sed -i 's/shure/sure/g' {} \;`
sweep on the whole repo to correct the

shure => sure
allready => already

typos.

Mainly directed towards the `"File allready exists, are you shure? (yes/no)"` typo in the message radium prints when aborting a .rad file without saving changes.