### PR TITLE
Fix LLVM 4.0 incompat with faust

### DIFF
--- a/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
@@ -121,7 +121,11 @@ class LLVMCodeContainer : public virtual CodeContainer {
 
         LlvmValue genFloat(const string& number)
         {
+        #if defined(LLVM_40)
+            return ConstantFP::get(getContext(), APFloat(APFloat::IEEEsingle(), number));
+        #else
             return ConstantFP::get(getContext(), APFloat(APFloat::IEEEsingle, number));
+        #endif
         }
 
         LlvmValue genFloat(float number)


### PR DESCRIPTION
This completes #903 with upstream fixes that were missing at the time of
the pull req
https://github.com/grame-cncm/faust/commit/f261a90ca915c06dee9e3a8e62a69664fe17082d

Radium now compiles and runs with llvm 4.0 libs