### PR TITLE
Initial LLVM 5.0.0 support in Faust2 package

### DIFF
--- a/bin/packages/faust2/architecture/scheduler.cpp
+++ b/bin/packages/faust2/architecture/scheduler.cpp
@@ -642,7 +642,7 @@ static INLINE int Range(int min, int max, int val)
     }
 }
 
-#if defined(LLVM_40) || defined(LLVM_39) || defined(LLVM_38) || defined(LLVM_37) || defined(LLVM_36) || defined(LLVM_35) || defined(LLVM_34) || defined(LLVM_33) || defined(LLVM_32) || defined(LLVM_31)
+#if defined(LLVM_50) || defined(LLVM_40) || defined(LLVM_39) || defined(LLVM_38) || defined(LLVM_37) || defined(LLVM_36) || defined(LLVM_35) || defined(LLVM_34) || defined(LLVM_33) || defined(LLVM_32) || defined(LLVM_31)
     extern "C" void computeThreadExternal(void* dsp, int num_thread) __attribute__((weak_import));
 #else
     void computeThreadExternal(void* dsp, int num_thread);

--- a/bin/packages/faust2/benchmark/Makefile
+++ b/bin/packages/faust2/benchmark/Makefile
@@ -60,10 +60,16 @@ CXX = /opt/local/libexec/llvm-3.9/bin/clang++
 LLC = /opt/local/libexec/llvm-3.9/bin/llc
 endif
 
-ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0))
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0, 4.0.1))
 LLVM_VERSION  = LLVM_40
 CXX = /opt/local/libexec/llvm-4.0/bin/clang++
 LLC = /opt/local/libexec/llvm-4.0/bin/llc
+endif
+
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 5.0.0))
+LLVM_VERSION  = LLVM_50
+CXX = /opt/local/libexec/llvm-5.0/bin/clang++
+LLC = /opt/local/libexec/llvm-5.0/bin/llc
 endif
 
 ifeq ($(system), Darwin)

--- a/bin/packages/faust2/compiler/Makefile.unix
+++ b/bin/packages/faust2/compiler/Makefile.unix
@@ -117,6 +117,11 @@ else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0 4.0.1))
     CLANGLIBS=$(CLANGLIBSLIST)
     CXXFLAGS += -std=gnu++11
 
+else ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 5.0.0))
+    LLVM_VERSION = LLVM_50
+    CLANGLIBS=$(CLANGLIBSLIST)
+    CXXFLAGS += -std=gnu++11
+
 else
     $(error "Unknown LLVM version $(LLVM_VERSION)")
 

--- a/bin/packages/faust2/compiler/generator/code_container.hh
+++ b/bin/packages/faust2/compiler/generator/code_container.hh
@@ -119,7 +119,7 @@ class CodeContainer : public virtual Garbageable {
         }
 
         void generateDAGLoopAux(CodeLoop* loop, BlockInst* loop_code, DeclareVarInst* count, int loop_num, bool omp = false);
-        void generateDAGLoopInternal(CodeLoop* loop, BlockInst* block, DeclareVarInst * count, bool omp);
+        void generateDAGLoopInternal(CodeLoop* loop, BlockInst* block, DeclareVarInst* count, bool omp);
 
       public:
 
@@ -350,8 +350,8 @@ class CodeContainer : public virtual Garbageable {
         const string& getClassName() { return fKlassName; }
 
         // UI construction
-        void addUIMacro(const string& str)  { fUIMacro.push_back(str); }
-        void addUICode(const string& str)	{ fUICode.push_back(str); }
+        void addUIMacro(const string& str) { fUIMacro.push_back(str); }
+        void addUICode(const string& str) { fUICode.push_back(str); }
 
         virtual CodeContainer* createScalarContainer(const string& name, int sub_container_type) = 0;
 

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.cpp
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.cpp
@@ -48,11 +48,11 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
     fResult->fModule->setDataLayout("e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128");
     fBuilder = new IRBuilder<>(getContext());
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50))
     // Set "-fast-math"
     FastMathFlags FMF;
     FMF.setUnsafeAlgebra();
-#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if (defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50))
     fBuilder->setFastMathFlags(FMF);
 #else
     fBuilder->SetFastMathFlags(FMF);
@@ -75,11 +75,11 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
     fResult = result;
     fBuilder = new IRBuilder<>(getContext());
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50))
     // Set "-fast-math"
     FastMathFlags FMF;
     FMF.setUnsafeAlgebra();
-#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if (defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50))
     fBuilder->setFastMathFlags(FMF);
 #else
     fBuilder->SetFastMathFlags(FMF);
@@ -196,9 +196,11 @@ void LLVMCodeContainer::generateComputeBegin(const string& counter)
     Function* llvm_compute = Function::Create(llvm_compute_type, GlobalValue::ExternalLinkage, "compute" + fKlassName, fResult->fModule);
     llvm_compute->setCallingConv(CallingConv::C);
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
+#if !defined(LLVM_50)
     llvm_compute->setDoesNotAlias(3U);
     llvm_compute->setDoesNotAlias(4U);
+#endif
 #elif defined(LLVM_32) 
     AttrBuilder attr_builder;
     attr_builder.addAttribute(Attributes::NoAlias);
@@ -266,7 +268,7 @@ void LLVMCodeContainer::generateGetSampleRate(int field_index)
 
     BasicBlock* block = BasicBlock::Create(getContext(), "entry_block", sr_fun);
     fBuilder->SetInsertPoint(block);
-#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
 #else
     Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -509,7 +511,7 @@ void LLVMCodeContainer::generateMetadata(llvm::PointerType* meta_type_ptr)
 
         Value* idx2[3];
         idx2[0] = load_meta_ptr;
-    #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         idx2[1] = fBuilder->CreateConstGEP2_32(type_def1, llvm_label1, 0, 0);
         idx2[2] = fBuilder->CreateConstGEP2_32(type_def2, llvm_label2, 0, 0);
     #else
@@ -991,7 +993,7 @@ void LLVMWorkStealingCodeContainer::generateComputeThreadExternal()
 
     Function* llvm_computethreadInternal = fResult->fModule->getFunction("computeThread");
     assert(llvm_computethreadInternal);
-#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     Value* fun_args[] = { fBuilder->CreateBitCast(arg1, fStruct_DSP_ptr), arg2 };
     CallInst* call_inst = fBuilder->CreateCall(llvm_computethreadInternal, fun_args);
 #else

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_code_container.hh
@@ -28,7 +28,7 @@
 #include "omp_code_container.hh"
 #include "wss_code_container.hh"
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/Support/FileSystem.h>
     #define sysfs_binary_flag sys::fs::F_None
 #elif defined(LLVM_34)
@@ -37,7 +37,7 @@
     #define sysfs_binary_flag raw_fd_ostream::F_Binary
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define STREAM_ERROR std::error_code
 #else
     #define STREAM_ERROR std::string
@@ -121,7 +121,7 @@ class LLVMCodeContainer : public virtual CodeContainer {
 
         LlvmValue genFloat(const string& number)
         {
-        #if defined(LLVM_40)
+        #if defined(LLVM_40) || defined(LLVM_50)
             return ConstantFP::get(getContext(), APFloat(APFloat::IEEEsingle(), number));
         #else
             return ConstantFP::get(getContext(), APFloat(APFloat::IEEEsingle, number));

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.cpp
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.cpp
@@ -42,21 +42,13 @@
 #include "exception.hh"
 #include "rn_base64.h"
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <system_error>
 #else
     #include <llvm/Support/system_error.h>
 #endif
 
-#if defined(LLVM_40)
-    #include <llvm/Bitcode/BitcodeWriter.h>
-    #include <llvm/Bitcode/BitcodeReader.h>
-    #include <llvm/Transforms/IPO/AlwaysInliner.h>
-#elif defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39)
-    #include <llvm/Bitcode/ReaderWriter.h>
-#endif
-
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/Module.h>
     #include <llvm/IR/LLVMContext.h>
     #include <llvm/IRReader/IRReader.h>
@@ -73,7 +65,7 @@
     #include <llvm/Support/IRReader.h>
 #endif
 
-#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/Analysis/TargetLibraryInfo.h>
     #include <llvm/Analysis/TargetTransformInfo.h>
     #include <llvm/IR/PassManager.h>
@@ -86,26 +78,34 @@
     #define PASS_MANAGER PassManager
     #define FUNCTION_PASS_MANAGER FunctionPassManager
 #endif
- 
+
+#if defined(LLVM_40) || defined(LLVM_50)
+    #include <llvm/Bitcode/BitcodeWriter.h>
+    #include <llvm/Bitcode/BitcodeReader.h>
+    #include <llvm/Transforms/IPO/AlwaysInliner.h>
+#elif defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39)
+    #include <llvm/Bitcode/ReaderWriter.h>
+#endif
+
 /* The file llvm/Target/TargetData.h was renamed to llvm/DataLayout.h in LLVM
  * 3.2, which itself appears to have been moved to llvm/IR/DataLayout.h in LLVM
  * 3.3.
  */
 #if defined(LLVM_32)
     #include <llvm/DataLayout.h>
-#elif !defined(LLVM_33) && !defined(LLVM_34) && !defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
+#elif !defined(LLVM_33) && !defined(LLVM_34) && !defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40) && !defined(LLVM_50)
     #ifndef _WIN32
-        #include <llvm/Target/TargetData.h>
+    #include <llvm/Target/TargetData.h>
     #endif
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/ExecutionEngine/MCJIT.h>
 #else
     #include <llvm/ExecutionEngine/JIT.h>
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/Verifier.h>
 #else
     #include <llvm/Analysis/Verifier.h>
@@ -115,7 +115,7 @@
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/LegacyPassNameParser.h>
     #include <llvm/Linker/Linker.h>
 #else
@@ -126,7 +126,7 @@
 #include <llvm/Support/Host.h>
 #include <llvm/Support/ManagedStatic.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/IRPrintingPasses.h>
     #define llvmcreatePrintModulePass(out) createPrintModulePass(out)
 #else
@@ -137,17 +137,17 @@
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Support/Threading.h>
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     #include "llvm/ExecutionEngine/ObjectCache.h"
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define OwningPtr std::unique_ptr
 #endif
 
 #include <llvm/Support/TargetSelect.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/Support/FileSystem.h>
     #define sysfs_binary_flag sys::fs::F_None
 #elif defined(LLVM_34)
@@ -156,13 +156,13 @@
     #define sysfs_binary_flag raw_fd_ostream::F_Binary
 #endif
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define GET_CPU_NAME llvm::sys::getHostCPUName().str()
 #else
     #define GET_CPU_NAME llvm::sys::getHostCPUName()
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define STREAM_ERROR std::error_code
     #define MEMORY_BUFFER MemoryBufferRef
     #define MEMORY_BUFFER_GET(buffer) (buffer.getBuffer())
@@ -176,7 +176,7 @@
     #define MEMORY_BUFFER_CREATE(stringref) (MemoryBuffer::getMemBuffer(stringref))
 #endif
 
-#if defined(LLVM_34) || defined(LLVM_35)  || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_34) || defined(LLVM_35)  || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define MAX_OPT_LEVEL 5
 #else 
     #define MAX_OPT_LEVEL 4
@@ -271,7 +271,7 @@ class FaustObjectCache : public ObjectCache {
 };
 #endif
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
 
 // Workaround for iOS compiled LLVM 3.6 missing symbol
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
@@ -325,7 +325,7 @@ static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
 }
 #endif
 
-#if defined(LLVM_40)
+#if defined(LLVM_40) || defined(LLVM_50)
 
 static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
                                 LLVMContext& Context,
@@ -361,7 +361,7 @@ static Module* ParseBitcodeFile(MEMORY_BUFFER Buffer,
 
 void* llvm_dsp_factory::loadOptimize(const string& function)
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     void* fun = (void*)fJIT->getFunctionAddress(function);
     if (fun) {
         return fun;
@@ -441,7 +441,7 @@ void llvm_dsp_factory::writeDSPFactoryToIRFile(const string& ir_code_path)
 
 bool llvm_dsp_factory::crossCompile(const std::string& target)
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     delete fObjectCache;
     fObjectCache = new FaustObjectCache();
     setTarget(target);
@@ -454,7 +454,7 @@ bool llvm_dsp_factory::crossCompile(const std::string& target)
 
 std::string llvm_dsp_factory::writeDSPFactoryToMachineAux(const std::string& target)
 { 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     if (target == "" || target == getTarget()) {
         return fObjectCache->getMachineCode();
     } else {
@@ -485,7 +485,7 @@ void llvm_dsp_factory::writeDSPFactoryToMachineFile(const std::string& machine_c
     out.flush();
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
 llvm_dsp_factory::llvm_dsp_factory(const string& sha_key, const string& machine_code, const string& target)
 {
     init("MachineDSP", "");
@@ -512,12 +512,12 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key, Module* module, LLVMCo
     fResult->fModule = module;
     fResult->fContext = context;
     
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     fObjectCache = NULL;
 #endif
 }
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
 void llvm_dsp_factory::LLVMFatalErrorHandler(const char* reason)
 {
     throw faustexception(reason);
@@ -537,10 +537,10 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key,
     if (llvm_dsp_factory::gInstance++ == 0) {
         
         // Install a LLVM error handler
-    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         LLVMInstallFatalErrorHandler(llvm_dsp_factory::LLVMFatalErrorHandler);
     #endif
-    #if (!defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)) // In LLVM 3.5 this is gone.
+    #if (!defined(LLVM_35) && !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40) && !defined(LLVM_50)) // In LLVM 3.5 this is gone.
         if (!llvm_start_multithreaded()) {
             printf("llvm_start_multithreaded error...\n");
         }
@@ -552,7 +552,7 @@ llvm_dsp_factory::llvm_dsp_factory(const string& sha_key,
     fExpandedDSP = expanded_dsp_content;
     fSHAKey = sha_key;
     fTarget = (target == "") ? fTarget = (llvm::sys::getDefaultTargetTriple() + ":" + GET_CPU_NAME) : target;  
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     fObjectCache = NULL;
 #endif
     
@@ -606,7 +606,7 @@ int llvm_dsp_factory::getOptlevel()
     return -1;
 }
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
 /// AddOptimizationPasses - This routine adds optimization passes
 /// based on selected optimization level, OptLevel. This routine
 /// duplicates llvm-gcc behaviour.
@@ -633,7 +633,7 @@ static void AddOptimizationPasses(PassManagerBase &MPM, FUNCTION_PASS_MANAGER &F
         }
         Builder.Inliner = createFunctionInliningPass(Threshold);
     } else {
-    #if defined(LLVM_40)
+    #if defined(LLVM_40) || defined(LLVM_50)
         Builder.Inliner = createAlwaysInlinerLegacyPass();
     #else
          Builder.Inliner = createAlwaysInlinerPass();
@@ -673,22 +673,22 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
     InitializeNativeTargetAsmParser();
     
     // For ObjectCache to work...
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     LLVMLinkInMCJIT();
 #endif
     
     // Restoring from machine code
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     if (fObjectCache) {
     
         // JIT
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         EngineBuilder builder(unique_ptr<Module>(fResult->fModule));
     #else
         EngineBuilder builder(fResult->fModule);
     #endif
         builder.setEngineKind(EngineKind::JIT);
-    #if !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
+    #if !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40) && !defined(LLVM_50)
         builder.setUseMCJIT(true);
     #endif
         TargetMachine* tm = builder.selectTarget();
@@ -713,7 +713,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         initializeVectorization(Registry);
         initializeIPO(Registry);
         initializeAnalysis(Registry);
-#if !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
+#if !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40) && !defined(LLVM_50)
         initializeIPA(Registry);
 #endif
         initializeTransformUtils(Registry);
@@ -721,7 +721,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         initializeInstrumentation(Registry);
         initializeTarget(Registry);
        
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         EngineBuilder builder(unique_ptr<Module>(fResult->fModule));
     #else
         EngineBuilder builder(fResult->fModule);
@@ -736,7 +736,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         // MCJIT does not work correctly (incorrect float numbers ?) when used with dynamic libLLVM
     #if (defined(LLVM_34) || defined(LLVM_35)) && !defined(_MSC_VER)
         builder.setUseMCJIT(true);
-    #elif !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40)
+    #elif !defined(LLVM_36) && !defined(LLVM_37) && !defined(LLVM_38) && !defined(LLVM_39) && !defined(LLVM_40) && !defined(LLVM_50)
         builder.setUseMCJIT(false);
     #endif
     
@@ -792,7 +792,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             PASS_MANAGER pm;
             FUNCTION_PASS_MANAGER fpm(fResult->fModule);
             
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) // Code taken from opt.cpp
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50) // Code taken from opt.cpp
             TargetLibraryInfoImpl TLII(Triple(fResult->fModule->getTargetTriple()));
             pm.add(new TargetLibraryInfoWrapperPass(TLII));
         #else
@@ -801,7 +801,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             pm.add(tli);
         #endif
 
-        #if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             fResult->fModule->setDataLayout(fJIT->getDataLayout());
         #elif defined(LLVM_37) // Code taken from opt.cpp
             fResult->fModule->setDataLayout(*fJIT->getDataLayout());
@@ -815,7 +815,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
         #endif
           
             // Add internal analysis passes from the target machine (mandatory for vectorization to work)
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) // Code taken from opt.cpp
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50) // Code taken from opt.cpp
             pm.add(createTargetTransformInfoWrapperPass(tm->getTargetIRAnalysis()));
         #else
             tm->addAnalysisPasses(pm);
@@ -839,7 +839,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             pm.add(createVerifierPass());
             
             if ((debug_var != "") && (debug_var.find("FAUST_LLVM4") != string::npos)) {
-            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
                 // TODO
             #else
                 tm->addPassesToEmitFile(pm, fouts(), TargetMachine::CGFT_AssemblyFile, true);
@@ -854,7 +854,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
             }
         }
         
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
         fObjectCache = new FaustObjectCache();
         fJIT->setObjectCache(fObjectCache);
     }
@@ -1003,7 +1003,7 @@ bool llvm_dsp_factory::initJIT(string& error_msg)
 
 llvm_dsp_factory::~llvm_dsp_factory()
 {
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     delete fObjectCache;
 #endif
     if (fJIT) {
@@ -1018,10 +1018,10 @@ llvm_dsp_factory::~llvm_dsp_factory()
     }
     
     if (--llvm_dsp_factory::gInstance == 0) {
-#if  (!defined(LLVM_35)) && (!defined(LLVM_36)) && (!defined(LLVM_37)) && (!defined(LLVM_38)) && !(defined(LLVM_39)) && !(defined(LLVM_40)) // In LLVM 3.5 this is gone.
+#if  (!defined(LLVM_35)) && (!defined(LLVM_36)) && (!defined(LLVM_37)) && (!defined(LLVM_38)) && (!defined(LLVM_39)) && (!defined(LLVM_40)) && (!defined(LLVM_50)) // In LLVM 3.5 this is gone.
         llvm_stop_multithreaded();
     #endif
-    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         LLVMResetFatalErrorHandler();
     #endif
     }
@@ -1123,7 +1123,7 @@ EXPORT std::string getLibFaustVersion() { return FAUSTVERSION; }
 EXPORT Module* load_single_module(const string filename, LLVMContext* context)
 {
     SMDiagnostic err;
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     Module* module = parseIRFile(filename, err, *context).get();
 #else
     Module* module = ParseIRFile(filename, err, *context);
@@ -1141,7 +1141,7 @@ EXPORT bool link_modules(Module* dst, Module* src, char* error_msg)
 {
     bool res = false;
 
-#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     if (Linker::linkModules(*dst, std::unique_ptr<Module>(src))) { // Don't know what I'm doing here. Could Linker::linkModules try to free the src pointer? -Kjetil
         snprintf(error_msg, 256, "cannot link module");
         
@@ -1441,7 +1441,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromBitcodeFile(const string& bit_code_pa
 {
     TLock lock(gDSPFactoriesLock);
   
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(bit_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromBitcodeFile failed : %s\n", ec.message().c_str());
@@ -1485,7 +1485,7 @@ static llvm_dsp_factory* readDSPFactoryFromIRAux(MEMORY_BUFFER buffer, const str
         setlocale(LC_ALL, "C");
         LLVMContext* context = new LLVMContext();
         SMDiagnostic err;
-    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         Module* module = parseIR(buffer, err, *context).get();  // ParseIR takes ownership of the given buffer, so don't delete it
     #else
         Module* module = ParseIR(buffer, err, *context);        // ParseIR takes ownership of the given buffer, so don't delete it
@@ -1522,7 +1522,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromIRFile(const string& ir_code_path, co
 {
     TLock lock(gDSPFactoriesLock);
  
- #if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+ #if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(ir_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromIRFile failed : %s\n", ec.message().c_str());
@@ -1550,7 +1550,7 @@ EXPORT void writeDSPFactoryToIRFile(llvm_dsp_factory* factory, const string& ir_
     }
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
     
 static llvm_dsp_factory* readDSPFactoryFromMachineAux(MEMORY_BUFFER buffer, const std::string& target)
 {
@@ -1594,7 +1594,7 @@ EXPORT llvm_dsp_factory* readDSPFactoryFromMachineFile(const std::string& machin
 {
     TLock lock(gDSPFactoriesLock);
     
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     ErrorOr<OwningPtr<MemoryBuffer>> buffer = MemoryBuffer::getFileOrSTDIN(machine_code_path);
     if (std::error_code ec = buffer.getError()) {
         printf("readDSPFactoryFromMachineFile failed : %s\n", ec.message().c_str());
@@ -1888,7 +1888,7 @@ EXPORT void writeCDSPFactoryToIRFile(llvm_dsp_factory* factory, const char* ir_c
     }
 }
 
-#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+#if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
 EXPORT llvm_dsp_factory* readCDSPFactoryFromMachine(const char* machine_code, const char* target)
 {
     return readDSPFactoryFromMachine(machine_code, target);

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_dsp_aux.hh
@@ -67,7 +67,7 @@ class llvm_dsp_factory : public smartable {
     
         ExecutionEngine* fJIT;
 
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER)
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
         FaustObjectCache* fObjectCache;
     #endif
         LLVMResult* fResult;
@@ -104,7 +104,7 @@ class llvm_dsp_factory : public smartable {
         
         bool crossCompile(const std::string& target);
       
-    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         static void LLVMFatalErrorHandler(const char* reason);
     #endif
     
@@ -120,7 +120,7 @@ class llvm_dsp_factory : public smartable {
               
         llvm_dsp_factory(const string& sha_key, Module* module, LLVMContext* context, const string& target, int opt_level = 0);
         
-    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)) && !defined(_MSC_VER) 
+    #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)) && !defined(_MSC_VER)
         llvm_dsp_factory(const string& sha_key, const string& machine_code, const string& target);
     #endif
       

--- a/bin/packages/faust2/compiler/generator/llvm/llvm_instructions.hh
+++ b/bin/packages/faust2/compiler/generator/llvm/llvm_instructions.hh
@@ -34,7 +34,7 @@ using namespace std;
 #include "exception.hh"
 #include "global.hh"
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/DerivedTypes.h>
     #include <llvm/IR/LLVMContext.h>
     #include <llvm/IR/Module.h>
@@ -44,7 +44,7 @@ using namespace std;
     #include <llvm/Module.h>
 #endif
 
-#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #define GET_ITERATOR(it) &(*(it))
 #else
     #define GET_ITERATOR(it) it
@@ -52,13 +52,13 @@ using namespace std;
 
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 
-#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/ExecutionEngine/MCJIT.h>
 #else
     #include <llvm/ExecutionEngine/JIT.h>
 #endif
 
-#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/PassManager.h>
 #else
     #include <llvm/PassManager.h>
@@ -67,7 +67,7 @@ using namespace std;
 #include <llvm/Transforms/Scalar.h>
 #include <llvm-c/BitWriter.h>
 
-#if defined(LLVM_40)
+#if defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/Bitcode/BitcodeWriter.h>
     #include <llvm/Bitcode/BitcodeReader.h>
 #else
@@ -77,13 +77,13 @@ using namespace std;
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Host.h>
 
-#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/Verifier.h>
 #else
     #include <llvm/Analysis/Verifier.h>
 #endif
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/IRBuilder.h>
 #elif defined(LLVM_32) 
     #include <llvm/IRBuilder.h>
@@ -92,7 +92,7 @@ using namespace std;
     #include <llvm/Support/IRBuilder.h>
 #endif
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
     #include <llvm/IR/DataLayout.h>
 #endif
 
@@ -291,7 +291,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
         VECTOR_OF_TYPES fDSPFields;
         int fDSPFieldsCounter;
         string fPrefix;
-    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+    #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
         DataLayout* fDataLayout;
     #endif
 
@@ -395,7 +395,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
             // llvm_create_dsp block
             BasicBlock* entry_func_llvm_create_dsp = BasicBlock::Create(fModule->getContext(), "entry", func_llvm_create_dsp);
 
-        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             CallInst* call_inst1 = CallInst::Create(func_malloc, genInt64(fModule, fDataLayout->getTypeSizeInBits(dsp_type)), "", entry_func_llvm_create_dsp);
         #else
             // Dynamically computed object size (see http://nondot.org/sabre/LLVMNotes/SizeOf-OffsetOf-VariableSizedStructs.txt)
@@ -583,7 +583,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
             initTypes(module);
         #if defined(LLVM_35) || defined(LLVM_36)
             fDataLayout = new DataLayout(*module->getDataLayout());
-        #elif defined(LLVM_34)  || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #elif defined(LLVM_34)  || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             fDataLayout = new DataLayout(module->getDataLayout());
         #endif
         }
@@ -592,7 +592,7 @@ class LLVMTypeInstVisitor : public DispatchVisitor, public LLVMTypeHelper {
         {
             // External object not covered by Garbageable, so delete it here
             delete fBuilder;
-        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             delete fDataLayout;
         #endif
         }
@@ -979,7 +979,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             GlobalVariable* llvm_key = addStringConstant(inst->fKey, type_def1);
             GlobalVariable* llvm_value = addStringConstant(inst->fValue, type_def2);
 
-         #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+         #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* const_string1 = fBuilder->CreateConstGEP2_32(type_def1, llvm_key, 0, 0);
             Value* const_string2 = fBuilder->CreateConstGEP2_32(type_def2, llvm_value, 0, 0);
          #else
@@ -993,7 +993,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 zone_ptr = Constant::getNullValue((itfloat() == Typed::kFloat) ? fTypeMap[Typed::kFloat_ptr] : fTypeMap[Typed::kDouble_ptr]);
             } else {
                 int field_index = fDSPFieldsNames[inst->fZone];
-            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
                 zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
             #else
                 zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1021,7 +1021,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(inst->fName);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_name = addStringConstant(inst->fName, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_name, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_name, 0, 0);
@@ -1043,7 +1043,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             idx[1] = mth_index;
             Value* mth_ptr = fBuilder->CreateInBoundsGEP(ui, MAKE_IXD(idx, idx+2));
             LoadInst* mth = fBuilder->CreateLoad(mth_ptr);
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* fun_args[] = { fUIInterface_ptr, const_string };
             CallInst* call_inst = fBuilder->CreateCall(mth, fun_args);
         #else
@@ -1080,7 +1080,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1094,7 +1094,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
             Value* fun_args[] = { fUIInterface_ptr, const_string, zone_ptr };
             CallInst* call_inst = fBuilder->CreateCall(mth, fun_args);
@@ -1131,7 +1131,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1144,7 +1144,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
         #else
             Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1191,7 +1191,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
             string name = replaceSpacesWithUnderscore(label);
             llvm::Type* type_def = 0;
             GlobalVariable* llvm_label = addStringConstant(label, type_def);
-       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+       #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* const_string = fBuilder->CreateConstGEP2_32(type_def, llvm_label, 0, 0);
        #else
             Value* const_string = fBuilder->CreateConstGEP2_32(llvm_label, 0, 0);
@@ -1205,7 +1205,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
 
             // Generates access to zone
             int field_index = fDSPFieldsNames[zone];
-        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+        #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
             Value* zone_ptr = fBuilder->CreateStructGEP(0, dsp, field_index);
         #else
             Value* zone_ptr = fBuilder->CreateStructGEP(dsp, field_index);
@@ -1352,7 +1352,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 function = Function::Create(fun_type, (inst->fType->fAttribute & FunTyped::kLocal) ? GlobalValue::InternalLinkage : GlobalValue::ExternalLinkage, inst->fName, fModule);
                 function->setCallingConv(CallingConv::C);
                 
-            #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+            #if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
                 // In order for auto-vectorization to correctly work with vectorizable math functions
                 if (find(gMathLibTable.begin(), gMathLibTable.end(), inst->fName) != gMathLibTable.end()) {
                     function->setDoesNotAccessMemory();
@@ -1473,7 +1473,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
         {
             if (named_address->fAccess & Address::kStruct) {
                 int field_index = fDSPFieldsNames[named_address->fName];
-            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
                 return fBuilder->CreateStructGEP(0, getDSP(), field_index);
             #else
                 return fBuilder->CreateStructGEP(getDSP(), field_index);
@@ -1645,7 +1645,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 
             if (named_address->fAccess & Address::kStruct) {
                 int field_index = fDSPFieldsNames[named_address->fName];
-            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+            #if defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
                 Value* store_ptr = fBuilder->CreateStructGEP(0, getDSP(), field_index);
             #else
                 Value* store_ptr = fBuilder->CreateStructGEP(getDSP(), field_index);
@@ -2319,7 +2319,7 @@ class LLVMInstVisitor : public InstVisitor, public LLVMTypeHelper {
                 // Inst result for comparison
                 return generateScalarSelect(opcode, comp_value, genInt32(fModule, 1, size), genInt32(fModule, 0, size), size);
             } else {
-            #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40))
+            #if (defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50))
                 LlvmValue value = fBuilder->CreateBinOp((Instruction::BinaryOps)gBinOpTable[opcode]->fLlvmFloatInst, arg1, arg2);
                 Instruction* inst = cast<Instruction>(value);
                 inst->setMetadata(LLVMContext::MD_fpmath, fBuilder->getDefaultFPMathTag());

--- a/bin/packages/faust2/compiler/signals/binop.cpp
+++ b/bin/packages/faust2/compiler/signals/binop.cpp
@@ -32,7 +32,7 @@ static bool noNtrl(const Node& n) { return falsePredicate(n); }
 
 #if LLVM_BUILD
 
-#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40)
+#if defined(LLVM_33) || defined(LLVM_34) || defined(LLVM_35) || defined(LLVM_36) || defined(LLVM_37) || defined(LLVM_38) || defined(LLVM_39) || defined(LLVM_40) || defined(LLVM_50)
 #include <llvm/IR/Instructions.h>
 #else
 #include <llvm/Instructions.h>

--- a/bin/packages/faust2/examples/Makefile.llvmcompile
+++ b/bin/packages/faust2/examples/Makefile.llvmcompile
@@ -52,7 +52,7 @@ LLVM_VERSION  = LLVM_39
 LLVM_PREFIX = /opt/local/libexec/llvm-3.9/bin
 endif
 
-ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0))
+ifeq ($(LLVM_VERSION),$(filter $(LLVM_VERSION), 4.0.0 4.0.1))
 LLVM_VERSION  = LLVM_40
 LLVM_PREFIX = /opt/local/libexec/llvm-4.0/bin
 endif


### PR DESCRIPTION
This updates faust2's filters to recognise LLVM 5.0.0, but faust2 will
not compile with LLVM5 yet.

See #1068

Taken from upstream faust2
https://github.com/grame-cncm/faust/commit/bebc10bd987a736c25b3671d447d05a4b515a759
https://github.com/grame-cncm/faust/commit/428853ed1705d7491cf57283a9e2182a77877ca5