### PR TITLE
Suppress Mesa startup warning for amdgpu driver

### DIFF
--- a/OpenGL/Widget.cpp
+++ b/OpenGL/Widget.cpp
@@ -2116,7 +2116,7 @@ QWidget *GL_create_widget(QWidget *parent){
 
 
     
-    if (s_version.contains("mesa", Qt::CaseInsensitive) && show_mesa_warning==true)
+    if (s_version.contains("mesa", Qt::CaseInsensitive) != s_renderer.contains("DRM 3") && show_mesa_warning==true)
       GFX_Message(NULL,
                   "Warning!\n"
                   "MESA OpenGL driver detected.\n"


### PR DESCRIPTION
When using the linux amdgpu driver on AMD graphic cards
the Mesa warning displays at every startup without a way to turn it off

This hides that warning from appearing on amdgpu by checking for DRM
version (amdgpu is DRM 3.X.X and up)

For reference, this is what radium prints when I use `amdgpu`.
```
vendor: X.Org, renderer: AMD Radeon HD 7800 Series (PITCAIRN / DRM 3.19.0 / 4.14.10-1-ck-k10, LLVM 5.0.1), version: 3.0 Mesa 17.3.1
Debug: ___ GE_version_string:  "3.0 Mesa 17.3.1" (OpenGL/Widget.cpp:1905, QWidget* GL_create_widget(QWidget*))
```