### PR TITLE
Hide Mesa startup warning for AMD devices

### DIFF
--- a/OpenGL/Widget.cpp
+++ b/OpenGL/Widget.cpp
@@ -2177,7 +2177,7 @@ QWidget *GL_create_widget(QWidget *parent){
 
 
     
-    if (s_version.contains("mesa", Qt::CaseInsensitive) != s_renderer.contains("DRM 3") && show_mesa_warning==true)
+    if (s_version.contains("mesa", Qt::CaseInsensitive) != s_renderer.contains("AMD") && show_mesa_warning==true)
       GFX_Message(NULL,
                   "Warning!\n"
                   "MESA OpenGL driver detected.\n"


### PR DESCRIPTION
This is a simple change to commit in pullreq #1102 to exclude AMD altogether as `radeon` driver also prints the "mesa" string in OpenGL renderer version now:

```
Debug: ___ GE_version_string:  "4.4 (Compatibility Profile) Mesa 18.2.0" (OpenGL/Widget.cpp:1962, QWidget* GL_create_widget(QWidget*))
vendor: X.Org, renderer: AMD PITCAIRN (DRM 2.50.0, 4.18.7-2-ck, LLVM 6.0.1), version: 4.4 (Compatibility Profile) Mesa 18.2.0
```

The two `radeon` and `amdgpu` open-source drivers use hardware accelerated Mesa so the nag warning shouldn't apply.

Proprietary Catalyst isn't supported by AMD anymore I think, amdgpu-pro is its successor.