### PR TITLE
Add LLVM9 support to faust patch

### DIFF
--- a/bin/packages/faust.patch
+++ b/bin/packages/faust.patch
@@ -1,5 +1,5 @@
 diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
-index ece37cb..e99dfae 100644
+index ece37cb0b..ff2b549e0 100644
 --- a/build/CMakeLists.txt
 +++ b/build/CMakeLists.txt
 @@ -84,8 +84,8 @@ if (INCLUDE_LLVM )
@@ -14,7 +14,7 @@ index ece37cb..e99dfae 100644
  	set (FAUST_LIBS ${FAUST_LIBS} ${LLVM_LD_FLAGS} ${LLVM_LIBS})
  	
 diff --git a/build/backends/most.cmake b/build/backends/most.cmake
-index c6333e5..0589c5d 100644
+index c6333e550..0589c5d41 100644
 --- a/build/backends/most.cmake
 +++ b/build/backends/most.cmake
 @@ -8,14 +8,14 @@
@@ -41,3 +41,120 @@ index c6333e5..0589c5d 100644
 +set ( RUST_BACKEND   OFF       CACHE STRING  "Include RUST backend"      FORCE )
 +set ( SOUL_BACKEND   OFF         CACHE STRING  "Include SOUL backend"      FORCE )
 +set ( WASM_BACKEND   OFF  WASM   CACHE STRING  "Include WASM backend"      FORCE )
+ 
+diff --git a/compiler/generator/llvm/llvm_code_container.cpp b/compiler/generator/llvm/llvm_code_container.cpp
+index 07df9dc32..1d1c717d8 100644
+--- a/compiler/generator/llvm/llvm_code_container.cpp
++++ b/compiler/generator/llvm/llvm_code_container.cpp
+@@ -71,7 +71,7 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
+ 
+     // Set "-fast-math"
+     FastMathFlags FMF;
+-#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     FMF.setFast();  // has replaced the below function
+ #else
+     FMF.setUnsafeAlgebra();
+@@ -91,7 +91,7 @@ LLVMCodeContainer::LLVMCodeContainer(const string& name, int numInputs, int numO
+ 
+     // Set "-fast-math"
+     FastMathFlags FMF;
+-#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     FMF.setFast();  // has replaced the below function
+ #else
+     FMF.setUnsafeAlgebra();
+diff --git a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+index 55f173e86..a0db47d17 100644
+--- a/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
++++ b/compiler/generator/llvm/llvm_dynamic_dsp_aux.cpp
+@@ -109,7 +109,7 @@ void llvm_dynamic_dsp_factory_aux::write(ostream* out, bool binary, bool small)
+     string             res;
+     raw_string_ostream out_str(res);
+     if (binary) {
+-#if defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+         WriteBitcodeToFile(*fModule, out_str);
+ #else
+         WriteBitcodeToFile(fModule, out_str);
+@@ -126,7 +126,7 @@ string llvm_dynamic_dsp_factory_aux::writeDSPFactoryToBitcode()
+     string res;
+     
+     raw_string_ostream out(res);
+-#if defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     WriteBitcodeToFile(*fModule, out);
+ #else
+     WriteBitcodeToFile(fModule, out);
+@@ -143,7 +143,7 @@ bool llvm_dynamic_dsp_factory_aux::writeDSPFactoryToBitcodeFile(const string& bi
+         cerr << "ERROR : writeDSPFactoryToBitcodeFile could not open file : " << err.message();
+         return false;
+     }
+-#if defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     WriteBitcodeToFile(*fModule, out);
+ #else
+     WriteBitcodeToFile(fModule, out);
+@@ -204,7 +204,7 @@ static void AddOptimizationPasses(PassManagerBase& MPM, FUNCTION_PASS_MANAGER& F
+         }
+         Builder.Inliner = createFunctionInliningPass(Threshold);
+     } else {
+-#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+         Builder.Inliner = createAlwaysInlinerLegacyPass();
+ #else
+         Builder.Inliner = createAlwaysInlinerPass();
+@@ -263,7 +263,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
+ 
+     builder.setOptLevel(CodeGenOpt::Aggressive);
+     builder.setEngineKind(EngineKind::JIT);
+-#if !defined(LLVM_60) && !defined(LLVM_70) && !defined(LLVM_80)
++#if !defined(LLVM_60) && !defined(LLVM_70) && !defined(LLVM_80) && !defined(LLVM_90)
+     builder.setCodeModel(CodeModel::JITDefault);
+ #endif
+ 
+@@ -278,7 +278,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
+     TargetOptions targetOptions;
+ 
+     // -fastmath is activated at IR level, and has to be setup at JIT level also
+-#if !defined(LLVM_50) && !defined(LLVM_60) && !defined(LLVM_70) && !defined(LLVM_80)
++#if !defined(LLVM_50) && !defined(LLVM_60) && !defined(LLVM_70) && !defined(LLVM_80) && !defined(LLVM_90)
+     targetOptions.LessPreciseFPMADOption = true;
+ #endif
+     targetOptions.AllowFPOpFusion       = FPOpFusion::Fast;
+@@ -287,7 +287,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
+     targetOptions.NoNaNsFPMath          = true;
+     targetOptions.GuaranteedTailCallOpt = true;
+ 
+-#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     targetOptions.NoTrappingFPMath = true;
+     targetOptions.FPDenormalMode   = FPDenormal::IEEE;
+ #endif
+@@ -329,7 +329,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
+         }
+ 
+         if ((debug_var != "") && (debug_var.find("FAUST_LLVM1") != string::npos)) {
+-#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+             // TargetRegistry::printRegisteredTargetsForVersion(cout);
+ #else
+             TargetRegistry::printRegisteredTargetsForVersion();
+@@ -345,7 +345,7 @@ bool llvm_dynamic_dsp_factory_aux::initJIT(string& error_msg)
+         pm.add(createVerifierPass());
+ 
+         if ((debug_var != "") && (debug_var.find("FAUST_LLVM4") != string::npos)) {
+-#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_50) || defined(LLVM_60) || defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+             // TODO
+ #else
+             tm->addPassesToEmitFile(pm, fouts(), TargetMachine::CGFT_AssemblyFile, true);
+@@ -524,7 +524,7 @@ bool llvm_dynamic_dsp_factory_aux::writeDSPFactoryToObjectcodeFileAux(const stri
+     legacy::PassManager pass;
+     auto                FileType = TargetMachine::CGFT_ObjectFile;
+ 
+-#if defined(LLVM_70) || defined(LLVM_80)
++#if defined(LLVM_70) || defined(LLVM_80) || defined(LLVM_90)
+     if (TheTargetMachine->addPassesToEmitFile(pass, dest, nullptr, FileType)) {
+ #else
+     if (TheTargetMachine->addPassesToEmitFile(pass, dest, FileType, true)) {


### PR DESCRIPTION
Stable April 12th (https://github.com/grame-cncm/faust/commit/324b6130fcc7a54dc289e26f8583b84a786e7ebe) FAUST in repo doesn't build with LLVM9
This commit appends the updated conditionals to faust.patch so that
radium can build on machines with LLVM 9.0

Lifted from upstream faust-dev
https://github.com/grame-cncm/faust/commit/949e63baa6364d09b4b60f6adc33200ba2133d6f