### PR TITLE
Build: Allow skipping libxcb compile with env vars

### DIFF
--- a/bin/packages/build.sh
+++ b/bin/packages/build.sh
@@ -207,7 +207,7 @@ then
     cd ../
 fi
 
-if [[ $RADIUM_QT_VERSION == 5 ]]
+if [[ $RADIUM_QT_VERSION == 5 && $RADIUM_BUILD_LIBXCB != 0 ]]
 then
 
     rm -fr xcb-proto-1.13/

--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,10 @@ rm -f libpds.o
 cd "$THIS_DIR/bin"
 
 # libxcb
-cp -a packages/libxcb-1.13 "$TARGET/packages/"
-cd "$TARGET/packages/libxcb-1.13/src"
-rm -f *.o
-cd "$THIS_DIR/bin"
+if [[ $RADIUM_INSTALL_LIBXCB != 0 ]]
+then
+    cp -a packages/libxcb-1.13 "$TARGET/packages/"
+    cd "$TARGET/packages/libxcb-1.13/src"
+    rm -f ./*.o
+    cd "$THIS_DIR/bin"
+fi


### PR DESCRIPTION
Commit 0faf13e20d26446defe92c9b68f883892bbf928f allows users to not have
to use bundled libxcb at runtime but it's still required to build it.

With this patch it's possible to pass
RADIUM_BUILD_LIBXCB=0 to make packages and
RADIUM_INSTALL_LIBXCB=0 to install.sh

to skip building libxcb as well.