### PR TITLE
Build: Switch to clang for libpd-master compile

### DIFF
--- a/bin/packages/build.sh
+++ b/bin/packages/build.sh
@@ -132,6 +132,7 @@ cd libpd-master/
 sed -i '/define CFLAGS/ s|")| -I/usr/include/tirpc ")|' make.scm
 sed -i 's/k_cext$//' make.scm
 sed -i 's/oscx //' make.scm
+sed -i 's/gcc -O3/clang -Wno-return-type -O3/' make.scm
 make clean
 make -j`nproc`
 cd ..


### PR DESCRIPTION
I've getting strange linker errors when running make in libpd-master on gcc 10.1.0

```
cc -o libs/libpd.so pure-data/src/g_canvas.o pure-data/src/g_graph.o pure-data/src/g_text.o pure-data/src/g_rtext.o pure-data/src/g_array.o pure-data/src/g_template.o pure-data/src/g_io.
o pure-data/src/g_scalar.o pure-data/src/g_traversal.o pure-data/src/g_guiconnect.o pure-data/src/g_readwrite.o pure-data/src/g_editor.o pure-data/src/g_all_guis.o pure-data/src/m_pd.o p
ure-data/src/m_class.o pure-data/src/m_obj.o pure-data/src/m_atom.o pure-data/src/m_memory.o pure-data/src/m_binbuf.o pure-data/src/m_conf_pdextended.o pure-data/src/m_glob.o pure-data/s
rc/m_sched.o pure-data/src/s_main.o pure-data/src/s_inter.o pure-data/src/s_file.o pure-data/src/s_loader.o pure-data/src/s_path.o pure-data/src/s_entry.o pure-data/src/s_audio.o pure-da
ta/src/s_utf8.o pure-data/src/d_ugen.o pure-data/src/d_ctl.o pure-data/src/d_arithmetic.o pure-data/src/d_osc.o pure-data/src/d_filter.o pure-data/src/d_math.o pure-data/src/d_array.o pu
re-data/src/d_global.o pure-data/src/d_delay.o pure-data/src/d_resample.o pure-data/src/x_arithmetic.o pure-data/src/x_connective.o pure-data/src/x_acoustics.o pure-data/src/d_soundfile.
o pure-data/src/e_fft.o pure-data/src/e_gfxstub.o pure-data/src/e_dac.o pure-data/src/e_midi.o pure-data/src/g_magicglass.o pure-data/src/import.o pure-data/src/path.o pure-data/src/clos
ebang.o pure-data/src/initbang.o pure-data/src/s_print.o pure-data/src/d_fft_mayer.o pure-data/src/d_fftroutine.o pure-data/src/s_audio_dummy.o pure-data/extra/expr~/vexp_fun.o pure-data
/extra/expr~/vexp_if.o pure-data/extra/expr~/vexp.o libpd_wrapper/s_libpdmidi.o libpd_wrapper/x_libpdreceive.o libpd_wrapper/z_libpd.o loader-file.o `./make.scm print-object-files` -shar
ed -ldl -Wl,-Bsymbolic -lm -lpthread -lfftw3f -lfftw3 -logg -lvorbis -lvorbisfile -lvorbisenc -lspeex
/usr/bin/ld: externalobjs/breakpoints~.c.o:/tmp/libpd-master/externals/tof/src/breakpoints~.h:61: multiple definition of `breakpoints_widgetbehavior'; externalobjs/breakpoints.c.o:/tmp/l
ibpd-master/externals/tof/src/breakpoints~.h:61: first defined here
/usr/bin/ld: externalobjs/breakpoints~.c.o:/tmp/libpd-master/externals/tof/src/breakpoints~.c:27: multiple definition of `dumpy'; externalobjs/breakpoints.c.o:/tmp/libpd-master/externals
/tof/src/breakpoints.c:27: first defined here
/usr/bin/ld: externalobjs/dinlet~.c.o:(.bss+0x0): multiple definition of `vinlet_class'; pure-data/src/g_io.o:(.bss+0x8): first defined here
/usr/bin/ld: externalobjs/del16write~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_delay.h:23: multiple definition of `sigdel16write_class'; externalobjs/del16read~.c.o:/tmp/libpd-mas
ter/externals/iem16/src/iem16_delay.h:23: first defined here
/usr/bin/ld: externalobjs/tab16read.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/exte
rnals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16read4.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ext
ernals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16read4~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ex
ternals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16read~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ext
ernals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16receive~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/
externals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16send~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ext
ernals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16write.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ext
ernals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/tab16write~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/ex
ternals/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/table16.c.o:/tmp/libpd-master/externals/iem16/src/iem16_table.h:17: multiple definition of `table16_class'; externalobjs/tab16play~.c.o:/tmp/libpd-master/extern
als/iem16/src/iem16_table.h:17: first defined here
/usr/bin/ld: externalobjs/vd16~.c.o:/tmp/libpd-master/externals/iem16/src/iem16_delay.h:23: multiple definition of `sigdel16write_class'; externalobjs/del16read~.c.o:/tmp/libpd-master/ex
ternals/iem16/src/iem16_delay.h:23: first defined here
/usr/bin/ld: externalobjs/receive13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:3: multiple definition of `sigreceive13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/extern
als/ext13/d_global13.h:3: first defined here
/usr/bin/ld: externalobjs/receive13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:1: multiple definition of `sigsend13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals
/ext13/d_global13.h:1: first defined here
/usr/bin/ld: externalobjs/receive13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:4: multiple definition of `sigcatch13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/external
s/ext13/d_global13.h:4: first defined here
/usr/bin/ld: externalobjs/receive13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:2: multiple definition of `sigthrow13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/external
s/ext13/d_global13.h:2: first defined here
/usr/bin/ld: externalobjs/send13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:1: multiple definition of `sigsend13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/ex
t13/d_global13.h:1: first defined here
/usr/bin/ld: externalobjs/send13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:4: multiple definition of `sigcatch13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/e
xt13/d_global13.h:4: first defined here
/usr/bin/ld: externalobjs/send13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:3: multiple definition of `sigreceive13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals
/ext13/d_global13.h:3: first defined here
/usr/bin/ld: externalobjs/send13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:2: multiple definition of `sigthrow13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/e
xt13/d_global13.h:2: first defined here
/usr/bin/ld: externalobjs/throw13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:2: multiple definition of `sigthrow13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/
ext13/d_global13.h:2: first defined here
/usr/bin/ld: externalobjs/throw13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:4: multiple definition of `sigcatch13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/
ext13/d_global13.h:4: first defined here
/usr/bin/ld: externalobjs/throw13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:3: multiple definition of `sigreceive13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/external
s/ext13/d_global13.h:3: first defined here
/usr/bin/ld: externalobjs/throw13~.c.o:/tmp/libpd-master/externals/ext13/d_global13.h:1: multiple definition of `sigsend13_class'; externalobjs/catch13~.c.o:/tmp/libpd-master/externals/e
xt13/d_global13.h:1: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:185: libs/libpd.so] Error 1
```
The easiest workaround I found is to just use clang for this package, that works.

Just a heads up, you can close this if you don't get this issue in your build environment.