### PR TITLE
Build: Fix FAUST HTTPDServer compile

### DIFF
--- a/bin/packages/build.sh
+++ b/bin/packages/build.sh
@@ -100,6 +100,7 @@ mv faustlibraries-master libraries
 patch -p0 <../faust.patch
 patch -p1 <../faust_setlocale.patch
 patch -p0 <../faust_svgfix.patch
+patch -p1 <../faust_HTTPDServer.patch 
 if env |grep INCLUDE_FAUSTDEV_BUT_NOT_LLVM ; then
     patch -p0 <../faust_nollvm.patch
 fi

--- a/bin/packages/faust_HTTPDServer.patch
+++ b/bin/packages/faust_HTTPDServer.patch
@@ -1,0 +1,571 @@
+From 8ccdc687572ec8de0e525b668c86611a3033e3fc Mon Sep 17 00:00:00 2001
+From: Stephane Letz <letz@grame.fr>
+Date: Wed, 22 Jul 2020 11:41:52 +0200
+Subject: [PATCH] Cleanup code using libmicrohttp library to use MHD_Result
+ type and do proper typing.
+
+---
+ .../httpdlib/src/httpd/HTTPDServer.cpp        | 421 +++++++++---------
+ architecture/httpdlib/src/httpd/HTTPDServer.h | 104 ++---
+ 2 files changed, 262 insertions(+), 263 deletions(-)
+
+diff --git a/architecture/httpdlib/src/httpd/HTTPDServer.cpp b/architecture/httpdlib/src/httpd/HTTPDServer.cpp
+index 0c5dfa67d..47a51ea66 100644
+--- a/architecture/httpdlib/src/httpd/HTTPDServer.cpp
++++ b/architecture/httpdlib/src/httpd/HTTPDServer.cpp
+@@ -1,25 +1,25 @@
+ /*
+-
+-  Copyright (C) 2011 Grame
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, write to the Free Software
+-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-
+-  Grame Research Laboratory, 9 rue du Garet, 69001 Lyon - France
+-  research@grame.fr
+-
+-*/
++ 
++ Copyright (C) 2011 Grame
++ 
++ This library is free software; you can redistribute it and/or
++ modify it under the terms of the GNU Lesser General Public
++ License as published by the Free Software Foundation; either
++ version 2.1 of the License, or (at your option) any later version.
++ 
++ This library is distributed in the hope that it will be useful,
++ but WITHOUT ANY WARRANTY; without even the implied warranty of
++ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ Lesser General Public License for more details.
++ 
++ You should have received a copy of the GNU Lesser General Public
++ License along with this library; if not, write to the Free Software
++ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ 
++ Grame Research Laboratory, 9 rue du Garet, 69001 Lyon - France
++ research@grame.fr
++ 
++ */
+ 
+ #include <iostream>
+ #include <sstream>
+@@ -42,199 +42,198 @@ using namespace std;
+ 
+ namespace httpdfaust
+ {
+-
+-#define kPortsScanRange		1000		// scan this number of TCP ports to find a free one (in case of busy port)
+-
+-//--------------------------------------------------------------------------
+-// static functions
+-// provided as callbacks to mhttpd
+-//--------------------------------------------------------------------------
+-static int _answer_to_connection (void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, 
+-                          const char *upload_data, size_t *upload_data_size, void **con_cls)
+-{
+-	HTTPDServer* server = (HTTPDServer*)cls;
+-	return server->answer(connection, url, method, version, upload_data, upload_data_size, con_cls); 
+-}
+-
+-// Convert string to float. Accepts both . and , as decimal point
+-// Syntax is : [ ]*[+|-]n*(.|,)n*
+-static float mystrtof(const char* str, const char** endptr)
+-{
+-	const char* p = str;
+-	float		sign = 1.0;
+-	float		val = 0;
+-	
+-	// skip leading white spaces
+-	while (isspace(*p)) p++;
+-	// analyze sign
+-	if (*p == '-') { sign = -1.0; p++; }
+-	else if (*p == '+') { sign = 1.0; p++; }
+-	// fix part
+-	while (isdigit(*p)) { val = val*10 + (*p++ - '0'); }
+-	// decimal part
+-	if ((*p == '.') || (*p == ',')) {
+-		p++;
+-		// decimal part
+-		int virgule = 10; 
+-		while (isdigit(*p)) { 
+-			val = val + float(*p++ - '0')/virgule; 
+-			virgule *= 10; 
+-		}
+-	}
+-	*endptr = p;
+-	return sign*val;
+-}
+-
+-//--------------------------------------------------------------------------
+-// fonct(ion appelée par libmicrohttpd pour tous les parametres de la requète (soit GET soit POST)
+-static int _get_params (void *cls, enum MHD_ValueKind kind, const char *key, const char *value)
+-{
+-	Message* msg = (Message*)cls;
+-	msg->add (string(key));
+-	if (value) {
+-		const char* endptr;
+-		float fval = mystrtof(value, &endptr);
+-		if ((fval == 0) && (endptr == value))		// not a float value
+-			msg->add (string(value));
+-		else 
+-			msg->add (fval);
+-	}
+-	return MHD_YES;
+-}
+-
+-//--------------------------------------------------------------------------
+-// the http server
+-//--------------------------------------------------------------------------
+-HTTPDServer::HTTPDServer(MessageProcessor* mp)
+-	: fProcessor(mp), fServer(0), fDebug(false)
+-{
+-}
+-
+-HTTPDServer::~HTTPDServer() { stop(); }
+-
+-//--------------------------------------------------------------------------
+-bool HTTPDServer::start(int port)
+-{
+-	fServer = MHD_start_daemon (MHD_USE_SELECT_INTERNALLY, port, NULL, NULL, _answer_to_connection, this, MHD_OPTION_END);
+-	return fServer != 0;
+-}
+-
+-//--------------------------------------------------------------------------
+-int HTTPDServer::send (struct MHD_Connection *connection, const char *page, const char* type, int status)
+-{
+-	struct MHD_Response *response = MHD_create_response_from_buffer (strlen (page), (void *) page, MHD_RESPMEM_MUST_COPY);
+-	if (!response) {
+-		cerr << "MHD_create_response_from_buffer error: null response\n";
+-		return MHD_NO;
+-	}
+-	MHD_add_response_header (response, "Content-Type", type ? type : "text/plain");
+-	MHD_add_response_header (response, "Access-Control-Allow-Origin", "*");
+-	int ret = MHD_queue_response (connection, status, response);
+-	MHD_destroy_response (response);
+-	return ret;
+-}
+-
+-//--------------------------------------------------------------------------
+-const char* HTTPDServer::getMIMEType (const string& page)
+-{
+-	size_t n = page.find_last_of ('.');
+-	if (n != string::npos) {
+-		string ext = page.substr (n+1);
+-		if (ext == "css")	return "text/css";
+-		if (ext == "js")	return "application/javascript";
+-	}
+-	return "text/plain";		// default MIME type
+-}
+-
+-//--------------------------------------------------------------------------
+-int HTTPDServer::page (struct MHD_Connection *connection, const char * page)
+-{
+-	int ret = 0;
+-//	char * root =  getenv("FAUSTDocumentRoot");
+-	string file = ".";
+-	file += page;
+-	const char* type = getMIMEType (file);
+-
+-	int fd;
+-
++    
++#define kPortsScanRange 1000        // scan this number of TCP ports to find a free one (in case of busy port)
++    
++    //--------------------------------------------------------------------------
++    // static functions
++    // provided as callbacks to mhttpd
++    //--------------------------------------------------------------------------
++    static MHD_Result _answer_to_connection(void* cls, struct MHD_Connection* connection, const char* url, const char* method, const char* version,
++                                            const char* upload_data, long unsigned* upload_data_size, void** con_cls)
++    {
++        HTTPDServer* server = (HTTPDServer*)cls;
++        return server->answer(connection, url, method, version, upload_data, upload_data_size, con_cls);
++    }
++    
++    // Convert string to float. Accepts both . and , as decimal point
++    // Syntax is : [ ]*[+|-]n*(.|,)n*
++    static float mystrtof(const char* str, const char** endptr)
++    {
++        const char* p = str;
++        float    sign = 1.0;
++        float     val = 0;
++        
++        // skip leading white spaces
++        while (isspace(*p)) p++;
++        // analyze sign
++        if (*p == '-') { sign = -1.0; p++; }
++        else if (*p == '+') { sign = 1.0; p++; }
++        // fix part
++        while (isdigit(*p)) { val = val*10 + (*p++ - '0'); }
++        // decimal part
++        if ((*p == '.') || (*p == ',')) {
++            p++;
++            // decimal part
++            int virgule = 10;
++            while (isdigit(*p)) {
++                val = val + float(*p++ - '0')/virgule;
++                virgule *= 10;
++            }
++        }
++        *endptr = p;
++        return sign*val;
++    }
++    
++    //--------------------------------------------------------------------------
++    // fonct(ion appelée par libmicrohttpd pour tous les parametres de la requète (soit GET soit POST)
++    static MHD_Result _get_params(void* cls, enum MHD_ValueKind kind, const char* key, const char* value)
++    {
++        Message* msg = (Message*)cls;
++        msg->add (string(key));
++        if (value) {
++            const char* endptr;
++            float fval = mystrtof(value, &endptr);
++            if ((fval == 0) && (endptr == value)) {        // not a float value
++                msg->add (string(value));
++            } else {
++                msg->add (fval);
++            }
++        }
++        return MHD_YES;
++    }
++    
++    //--------------------------------------------------------------------------
++    // the http server
++    //--------------------------------------------------------------------------
++    HTTPDServer::HTTPDServer(MessageProcessor* mp)
++    : fProcessor(mp), fServer(nullptr), fDebug(false)
++    {}
++    
++    HTTPDServer::~HTTPDServer() { stop(); }
++    
++    //--------------------------------------------------------------------------
++    bool HTTPDServer::start(int port)
++    {
++        fServer = MHD_start_daemon (MHD_USE_SELECT_INTERNALLY, port, NULL, NULL, _answer_to_connection, this, MHD_OPTION_END);
++        return fServer != 0;
++    }
++    
++    //--------------------------------------------------------------------------
++    MHD_Result HTTPDServer::send(struct MHD_Connection* connection, const char* page, const char* type, int status)
++    {
++        struct MHD_Response* response = MHD_create_response_from_buffer(strlen (page), (void*) page, MHD_RESPMEM_MUST_COPY);
++        if (!response) {
++            cerr << "MHD_create_response_from_buffer error: null response\n";
++            return MHD_NO;
++        }
++        MHD_add_response_header(response, "Content-Type", type ? type : "text/plain");
++        MHD_add_response_header(response, "Access-Control-Allow-Origin", "*");
++        MHD_Result ret = MHD_queue_response(connection, status, response);
++        MHD_destroy_response(response);
++        return ret;
++    }
++    
++    //--------------------------------------------------------------------------
++    const char* HTTPDServer::getMIMEType(const string& page)
++    {
++        size_t n = page.find_last_of('.');
++        if (n != string::npos) {
++            string ext = page.substr (n+1);
++            if (ext == "css")   return "text/css";
++            if (ext == "js")    return "application/javascript";
++        }
++        return "text/plain";        // default MIME type
++    }
++    
++    //--------------------------------------------------------------------------
++    MHD_Result HTTPDServer::page(struct MHD_Connection* connection, const char* page)
++    {
++        MHD_Result ret = MHD_NO;
++        //    char * root =  getenv("FAUSTDocumentRoot");
++        string file = ".";
++        file += page;
++        const char* type = getMIMEType (file);
++        
++        int fd;
++        
+ #if defined(_WIN32) && !defined(__MINGW32__)
+-	int fhd;
+-	fd = _sopen_s(&fhd, file.c_str(), _O_RDONLY, _SH_DENYNO, _S_IREAD);
++        int fhd;
++        fd = _sopen_s(&fhd, file.c_str(), _O_RDONLY, _SH_DENYNO, _S_IREAD);
+ #else
+-	fd = open (file.c_str(), O_RDONLY);
++        fd = open (file.c_str(), O_RDONLY);
+ #endif
+-	if (fd != -1) {
+-		int length = lseek(fd, (long)0, SEEK_END);
+-		lseek(fd, 0, SEEK_SET);
+-		
+-		struct MHD_Response *response = MHD_create_response_from_fd (length, fd);
+-		if (!response ) {
+-			cerr << "MHD_create_response_from_fd error: null response\n";
+-			return MHD_NO;
+-		}
+-		MHD_add_response_header (response, "Content-Type", type ? type : "text/plain");
+-		MHD_add_response_header (response, "Access-Control-Allow-Origin", "*");
+-		ret = MHD_queue_response (connection, MHD_HTTP_OK, response);
+-		MHD_destroy_response (response);
+-	}
+-	else {
+-		ret = send (connection, "", 0, MHD_HTTP_NOT_FOUND);
+-	}
+-	return ret;
+-}
+-
+-//--------------------------------------------------------------------------
+-int HTTPDServer::send(struct MHD_Connection *connection, std::vector<Message*> msgs)
+-{
+-    stringstream page;
+-    string mime;
+-    for (unsigned int i=0; i<msgs.size(); i++) {
+-        string currentmime = msgs[i]->mimetype();
+-        if (mime.size() && (currentmime != mime)) {         // check for mime type change
+-            string res = page.str();
+-            send(connection, res.c_str(), mime.c_str());    // send the current mime data
+-            page.str("");                                   // and clear the stream
++        if (fd != -1) {
++            int length = lseek(fd, (long)0, SEEK_END);
++            lseek(fd, 0, SEEK_SET);
++            
++            struct MHD_Response* response = MHD_create_response_from_fd(length, fd);
++            if (!response) {
++                cerr << "MHD_create_response_from_fd error: null response\n";
++                return MHD_NO;
++            }
++            MHD_add_response_header(response, "Content-Type", type ? type : "text/plain");
++            MHD_add_response_header(response, "Access-Control-Allow-Origin", "*");
++            ret = MHD_queue_response(connection, MHD_HTTP_OK, response);
++            MHD_destroy_response(response);
++        } else {
++            ret = send(connection, "", 0, MHD_HTTP_NOT_FOUND);
+         }
+-        mime = currentmime;
+-        msgs[i]->print( page);
+-        page << endl;
+-        delete msgs[i];
++        return ret;
+     }
+-    string res = page.str();
+-    return send(connection, res.c_str(), mime.c_str());
+-}
+-
+-//--------------------------------------------------------------------------
+-// Callback appelée par libmicrohttpd
+-//--------------------------------------------------------------------------
+-int HTTPDServer::answer (struct MHD_Connection *connection, const char *url, const char *method, const char *version, 
+-					const char *upload_data, size_t *upload_data_size, void **con_cls)
+-{
+-	MHD_ValueKind t = MHD_GET_ARGUMENT_KIND;
+-	if (0 == strcmp (method, "GET"))		t = MHD_GET_ARGUMENT_KIND;
+-	else if (0 == strcmp (method, "POST"))	t = MHD_POSTDATA_KIND;
+-	else {
+-		string msg = "Method ";
+-		msg += method;
+-		msg += " is not supported";
+-		return send (connection, msg.c_str(), 0, MHD_HTTP_BAD_REQUEST);
+-	}
+-
+-	Message msg (url);
+-	MHD_get_connection_values (connection, t, _get_params, &msg);
+-	vector<Message*> outMsgs;
+-	if (fDebug) {
+-		cout << method << ": ";
+-		msg.print(cout);
+-		cout << endl;
+-	}
+-	fProcessor->processMessage (&msg, outMsgs);
+-	if (outMsgs.size())
+-		send (connection, outMsgs);
+-	else 
+-		page (connection, url);
+-	return MHD_YES;
+-}
+-
+-
++    
++    //--------------------------------------------------------------------------
++    MHD_Result HTTPDServer::send(struct MHD_Connection* connection, std::vector<Message*> msgs)
++    {
++        stringstream page;
++        string mime;
++        for (unsigned int i = 0; i < msgs.size(); i++) {
++            string currentmime = msgs[i]->mimetype();
++            if (mime.size() && (currentmime != mime)) {         // check for mime type change
++                string res = page.str();
++                send(connection, res.c_str(), mime.c_str());    // send the current mime data
++                page.str("");                                   // and clear the stream
++            }
++            mime = currentmime;
++            msgs[i]->print( page);
++            page << endl;
++            delete msgs[i];
++        }
++        string res = page.str();
++        return send(connection, res.c_str(), mime.c_str());
++    }
++    
++    //--------------------------------------------------------------------------
++    // Callback appelée par libmicrohttpd
++    //--------------------------------------------------------------------------
++    MHD_Result HTTPDServer::answer(struct MHD_Connection* connection, const char* url, const char* method, const char* version,
++                                   const char* upload_data, long unsigned* upload_data_size, void** con_cls)
++    {
++        MHD_ValueKind t = MHD_GET_ARGUMENT_KIND;
++        if (0 == strcmp (method, "GET"))        t = MHD_GET_ARGUMENT_KIND;
++        else if (0 == strcmp (method, "POST"))  t = MHD_POSTDATA_KIND;
++        else {
++            string msg = "Method ";
++            msg += method;
++            msg += " is not supported";
++            return send(connection, msg.c_str(), 0, MHD_HTTP_BAD_REQUEST);
++        }
++        
++        Message msg(url);
++        MHD_get_connection_values(connection, t, _get_params, &msg);
++        vector<Message*> outMsgs;
++        if (fDebug) {
++            cout << method << ": ";
++            msg.print(cout);
++            cout << endl;
++        }
++        fProcessor->processMessage(&msg, outMsgs);
++        if (outMsgs.size()) {
++            send(connection, outMsgs);
++        } else {
++            page(connection, url);
++        }
++        return MHD_YES;
++    }
++    
+ } // end namespoace
+diff --git a/architecture/httpdlib/src/httpd/HTTPDServer.h b/architecture/httpdlib/src/httpd/HTTPDServer.h
+index 6b016d86b..34d0eaba6 100644
+--- a/architecture/httpdlib/src/httpd/HTTPDServer.h
++++ b/architecture/httpdlib/src/httpd/HTTPDServer.h
+@@ -1,25 +1,25 @@
+ /*
+-
+-  Copyright (C) 2012 Grame
+-
+-  This library is free software; you can redistribute it and/or
+-  modify it under the terms of the GNU Lesser General Public
+-  License as published by the Free Software Foundation; either
+-  version 2.1 of the License, or (at your option) any later version.
+-
+-  This library is distributed in the hope that it will be useful,
+-  but WITHOUT ANY WARRANTY; without even the implied warranty of
+-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-  Lesser General Public License for more details.
+-
+-  You should have received a copy of the GNU Lesser General Public
+-  License along with this library; if not, write to the Free Software
+-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-
+-  Grame Research Laboratory, 9 rue du Garet, 69001 Lyon - France
+-  research@grame.fr
+-
+-*/
++ 
++ Copyright (C) 2012 Grame
++ 
++ This library is free software; you can redistribute it and/or
++ modify it under the terms of the GNU Lesser General Public
++ License as published by the Free Software Foundation; either
++ version 2.1 of the License, or (at your option) any later version.
++ 
++ This library is distributed in the hope that it will be useful,
++ but WITHOUT ANY WARRANTY; without even the implied warranty of
++ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ Lesser General Public License for more details.
++ 
++ You should have received a copy of the GNU Lesser General Public
++ License along with this library; if not, write to the Free Software
++ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
++ 
++ Grame Research Laboratory, 9 rue du Garet, 69001 Lyon - France
++ research@grame.fr
++ 
++ */
+ 
+ 
+ #ifndef __HTTPDServer__
+@@ -49,37 +49,37 @@
+ 
+ namespace httpdfaust
+ {
+-
+-class Message;
+-class MessageProcessor;
+-
+-//--------------------------------------------------------------------------
+-/*!
+-	\brief a specific thread to listen incoming osc packets
+-*/
+-class HTTPDServer
+-{
+-	MessageProcessor*	fProcessor;
+-	struct MHD_Daemon *	fServer;
+-	bool				fDebug;
+-	
+-	int send (struct MHD_Connection *connection, std::vector<Message*> msgs);
+-	int page (struct MHD_Connection *connection, const char *page);
+-	const char* getMIMEType (const std::string& page);
+-
+-	public:
+-				 HTTPDServer(MessageProcessor* mp);
+-		virtual ~HTTPDServer();
+-
+-		/// \brief starts the httpd server
+-		bool start (int port);
+-		void stop ()			{ if (fServer) MHD_stop_daemon (fServer); fServer=0; }
+-		int answer (struct MHD_Connection *connection, const char *url, const char *method, const char *version, 
+-					const char *upload_data, size_t *upload_data_size, void **con_cls);
+-
+-		static int send (struct MHD_Connection *connection, const char *page, const char *type, int status=MHD_HTTP_OK);
+-};
+-
++    
++    class Message;
++    class MessageProcessor;
++    
++    //--------------------------------------------------------------------------
++    /*!
++     \brief a specific thread to listen incoming osc packets
++     */
++    class HTTPDServer
++    {
++        MessageProcessor*  fProcessor;
++        struct MHD_Daemon* fServer;
++        bool               fDebug;
++        
++        MHD_Result send(struct MHD_Connection* connection, std::vector<Message*> msgs);
++        MHD_Result page(struct MHD_Connection* connection, const char* page);
++        const char* getMIMEType(const std::string& page);
++        
++    public:
++        HTTPDServer(MessageProcessor* mp);
++        virtual ~HTTPDServer();
++        
++        /// \brief starts the httpd server
++        bool start(int port);
++        void stop() { if (fServer) MHD_stop_daemon (fServer); fServer = nullptr; }
++        MHD_Result answer(struct MHD_Connection* connection, const char* url, const char* method, const char* version,
++                          const char* upload_data, long unsigned* upload_data_size, void **con_cls);
++        
++        static MHD_Result send(struct MHD_Connection* connection, const char* page, const char* type, int status = MHD_HTTP_OK);
++    };
++    
+ } // end namespoace
+ 
+ #endif


### PR DESCRIPTION
At least on GCC10, faust package failed to build on HTTPDServer.cpp, I've pulled this patch from upstream faust commit https://github.com/grame-cncm/faust/commit/8ccdc687572ec8de0e525b668c86611a3033e3fc
which fixed it, worth a push here IMO.