### PR TITLE
Build: Faust add missing include

### DIFF
--- a/bin/packages/build.sh
+++ b/bin/packages/build.sh
@@ -103,6 +103,7 @@ build_faust() {
         patch -p0 <../faust_nollvm.patch
     fi
     patch -p1 <../faust_llvm_fix.patch
+    patch -p0 <../faust_add_include.patch
     VERBOSE=1 CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" CMAKEOPT="-DCMAKE_BUILD_TYPE=Release -DSELF_CONTAINED_LIBRARY=on -DCMAKE_CXX_COMPILER=`which $DASCXX` -DCMAKE_C_COMPILER=`which $DASCC`" make most
     cd ..
 }

--- a/bin/packages/faust_add_include.patch
+++ b/bin/packages/faust_add_include.patch
@@ -1,0 +1,10 @@
+--- architecture/faust/gui/JSONUI.h~	2020-12-23 21:09:06.000000000 +0000
++++ architecture/faust/gui/JSONUI.h	2021-05-17 21:03:09.597254660 +0100
+@@ -32,6 +32,7 @@
+ #include <iomanip>
+ #include <sstream>
+ #include <algorithm>
++#include <limits>
+ 
+ #include "faust/gui/UI.h"
+ #include "faust/gui/PathBuilder.h"


### PR DESCRIPTION
Fix for faust build errors like `error: ‘max_digits10’ is not a member of ‘std::numeric_limits<float>’` due to missing stdlib include. From https://github.com/grame-cncm/faust/commit/81683c5d7f052941368908a1de30b462204edcc2