### PR TITLE
Preset browser

### DIFF
--- a/Makefile.Qt
+++ b/Makefile.Qt
@@ -550,7 +550,7 @@ OBJ11= $(T)undo.o $(T)undo_notes.o $(T)undo_fxs.o $(T)undo_temponodes.o $(T)undo
 #OBJ12= $(T)X11_visual.o $(T)X11_error.o $(T)X11_Ptask2Mtask.o $(T)X11_Bs_edit.o $(T)X11_Main.o $(T)X11_endprogram.o $(T)X11_disk.o $(T)X11_Player.o $(T)X11_memory.o $(T)X11_ReqType.o $(T)X11_keyboard.o $(T)X11_MidiProperties.o
 
 #Qt Spesific
-OBJ12= $(T)Qt_instruments.o $(T)Qt_visual.o $(T)GTK_visual.o $(T)Qt_Main.o $(T)KeyboardFocus.o $(T)Qt_endprogram.o $(T)Qt_EventReceiver.o $(T)Qt_colors.o $(T)Qt_Menues.o $(T)Qt_Fonts.o $(T)Qt_ReqType.o $(T)Qt_PopupMenu.o $(T)Qt_Bs_edit.o $(T)Qt_PluginWidget.o $(T)Qt_SliderPainter.o $(T)Qt_memory.o $(T)Qt_path_resolver.o $(T)Qt_settings.o $(T)Qt_disk.o $(T)Qt_MainWindow.o $(T)Qt_Time.o $(T)Qt_sequencer.o $(T)GTK_ReqType.o $(T)GTK_PopupMenu.o $(T)Qt_soundfilesaver_widget_callbacks.o $(T)Qt_comment_dialog.o $(T)Qt_song_properties.o $(T)Qt_preferences_callbacks.o $(T)Qt_tools_callbacks.o $(T)Qt_Error.o $(T)Qt_progresswindow.o $(T)Qt_check_for_updates.o $(T)Rational.o $(T)Qt_AutoBackups.o $(T)flowlayout.o
+OBJ12= $(T)Qt_instruments.o $(T)Qt_visual.o $(T)GTK_visual.o $(T)Qt_Main.o $(T)KeyboardFocus.o $(T)Qt_endprogram.o $(T)Qt_EventReceiver.o $(T)Qt_colors.o $(T)Qt_Menues.o $(T)Qt_Fonts.o $(T)Qt_ReqType.o $(T)Qt_PopupMenu.o $(T)Qt_Bs_edit.o $(T)Qt_PluginWidget.o $(T)Qt_SliderPainter.o $(T)Qt_memory.o $(T)Qt_path_resolver.o $(T)Qt_settings.o $(T)Qt_disk.o $(T)Qt_MainWindow.o $(T)Qt_Time.o $(T)Qt_sequencer.o $(T)GTK_ReqType.o $(T)GTK_PopupMenu.o $(T)Qt_soundfilesaver_widget_callbacks.o $(T)Qt_comment_dialog.o $(T)Qt_song_properties.o $(T)Qt_preferences_callbacks.o $(T)Qt_tools_callbacks.o $(T)Qt_Error.o $(T)Qt_progresswindow.o $(T)Qt_check_for_updates.o $(T)Rational.o $(T)Qt_AutoBackups.o $(T)flowlayout.o $(T)Qt_PresetBrowser.o
 
 #X11_MidiProperties.o $(T)X11_ClientMessages.o $(T)
 #Qt_Bs_edit.o $(T)
@@ -1629,6 +1629,19 @@ $(T)Qt_instruments.o: $(BUILD_DEPENDENCIES) $(P)Qt_instruments.cpp $(INSTRUMENTS
 
 #	$(CLANGCC) $(P)Qt_instruments.cpp $(QTOPT)
 # clang++ $(P)Qt_instruments.cpp $(QTOPT)
+
+
+$(T)Qt_PresetBrowser.o: $(BUILD_DEPENDENCIES) $(P)Qt_PresetBrowser.cpp $(INSTRUMENTS_DEPENDENCIES)
+	$(MOC) $(P)/Qt_PresetBrowser.cpp >$(P)/mQt_PresetBrowser.cpp
+	@echo
+	@echo "Changed (Qt_PresetBrowser.o):"
+	@echo $?
+	@echo
+	if [ $(BUILDTYPE) = RELEASE ] ; then \
+		$(CCC2) $(P)Qt_PresetBrowser.cpp $(QTOPT) $(SNDFILEOPT) -Wno-null-dereference  $(NO_ANALYZER) ; \
+	else \
+		$(CCC2) $(P)Qt_PresetBrowser.cpp $(QTOPT) $(SNDFILEOPT) -O0 -Wno-null-dereference $(NO_ANALYZER) ; \
+	fi
 
 
 $(P)mQt_instruments_widget_callbacks.h: $(BUILD_DEPENDENCIES) $(P)qt4_instruments_widget.ui $(P)create_source_from_ui.sh $(P)Qt_instruments_widget_callbacks.h

--- a/Qt/EditorWidget.h
+++ b/Qt/EditorWidget.h
@@ -90,6 +90,10 @@ struct EditorLayoutWidget : public radium::KeyboardFocusFrame{
     : radium::KeyboardFocusFrame(NULL, radium::KeyboardFocusFrameType::EDITOR, true)
   {
     set_widget_takes_care_of_painting_everything(this);
+    // set size policy to expanding with factor 10
+    QSizePolicy editorSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
+    editorSizePolicy.setHorizontalStretch(10);
+    setSizePolicy(editorSizePolicy);
   }
 };
 

--- a/Qt/FocusSniffers.h
+++ b/Qt/FocusSniffers.h
@@ -27,6 +27,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 #include <QTableWidgetItem>
 #include <QKeyEvent>
 #include <QComboBox>
+#include <QTreeView>
 //#include <QFileDialog>
 
 #include "helpers.h"
@@ -80,6 +81,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 //MakeFocusSnifferClass(QSpinBox);
 //MakeFocusSnifferClass(QDoubleSpinBox);
 MakeFocusSnifferClass(QLineEdit);
+MakeFocusSnifferClass(QTreeView);
 //MakeFocusSnifferClass(QComboBox);
 //MakeFocusSnifferClass(QFileDialog);
 //MakeFocusSnifferClass(QTextEdit);

--- a/Qt/Qt_Main.cpp
+++ b/Qt/Qt_Main.cpp
@@ -118,6 +118,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 #include "Qt_colors_proc.h"
 #include "Qt_AutoBackups_proc.h"
 #include "Qt_Bs_edit_proc.h"
+#include "Qt_PresetBrowser.h"
 
 #include "Timer.hpp"
 #include "mTimer.hpp"
@@ -3602,6 +3603,8 @@ int radium_main(const char *arg){
 
       if(xsplitter->_strip_on_left_side)
         xsplitter->add_mixer_strip();
+
+      xsplitter->addWidget(createPresetBrowserWidget());
 
       editor->editor_layout_widget = new EditorLayoutWidget();
       editor->editor_layout_widget->setMinimumWidth(550);

--- a/Qt/Qt_Main.cpp
+++ b/Qt/Qt_Main.cpp
@@ -3604,7 +3604,7 @@ int radium_main(const char *arg){
       if(xsplitter->_strip_on_left_side)
         xsplitter->add_mixer_strip();
 
-      xsplitter->addWidget(createPresetBrowserWidget());
+      xsplitter->addWidget(createPresetBrowserWidget(SETTINGS_read_qstring("preset_root_folder", QDir::homePath() + QString::fromUtf8("/Radium Presets"))));
 
       editor->editor_layout_widget = new EditorLayoutWidget();
       editor->editor_layout_widget->setMinimumWidth(550);

--- a/Qt/Qt_Main.cpp
+++ b/Qt/Qt_Main.cpp
@@ -3618,6 +3618,19 @@ int radium_main(const char *arg){
 
       block_selector->resize(100,block_selector->height());
 
+      // resize browser at start - without this browser gets a lot of space
+      QList<int> sizes = xsplitter->sizes();
+      int browserIndex = xsplitter->indexOf(getPresetBrowserWidgetFrame());
+      int editorIndex = xsplitter->indexOf(editor->editor_layout_widget);
+
+      if (browserIndex != -1 && editorIndex != -1) {
+        int space = sizes.at(browserIndex) + sizes.at(editorIndex);
+
+        sizes[browserIndex] = space * 0.3;
+        sizes[editorIndex] = space - sizes.at(browserIndex);
+        xsplitter->setSizes(sizes);
+      }
+
       {
         SEQUENCER_WIDGET_initialize(main_window);
         createInstrumentsWidget();

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -83,7 +83,9 @@ extern QApplication *qapplication;
 #include <QFileSystemModel>
 #include <QSortFilterProxyModel>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QDebug>
+#include <QButtonGroup>
 #include "../api/api_common_proc.h"
 
 #include <string>
@@ -210,18 +212,18 @@ class PresetBrowser : public QWidget
 
   public:
   PresetBrowser(QWidget *parent=NULL): QWidget(parent) {
+    // TODO: should be get from settings
+    presetFolder = "/home/and3md/akimaze/Radium/Presets";
+
     layout = new QVBoxLayout(this);
     layout->setSpacing(1);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setObjectName(QString::fromUtf8("vLayout"));
 
-    title = new QLabel("Presets", this);
+    title = new QLabel("Presets");
     layout->addWidget(title);
 
-    presetFolder = "/home/and3md/akimaze/Radium/Presets";
-
     model.setRootPath(presetFolder);
-    //filterModel.setRecursiveFilteringEnabled(true);
     filterModel.setSourceModel(&model);
     filterModel.setFilterRole((int)QFileSystemModel::FilePathRole);
     filterModel.setPresetFolder(presetFolder);
@@ -229,7 +231,6 @@ class PresetBrowser : public QWidget
     tree = new FocusSnifferQTreeView(this);
     tree->setModel(&filterModel);
     tree->setRootIndex(filterModel.mapFromSource(model.index(presetFolder)));
-    //tree->setRootIndex(filterModel.mapFromSource(model.index("")));
     tree->hideColumn(1);
     tree->hideColumn(2);
     tree->hideColumn(3);
@@ -237,10 +238,78 @@ class PresetBrowser : public QWidget
     layout->addWidget(tree);
 
     filterEdit = new FocusSnifferQLineEdit(this);
+    filterEdit->setPlaceholderText("Search");
     layout->addWidget(filterEdit);
 
-    presetDemoInstrument = createIllegalInstrument();
+    noteSharpButtonsLayout = new QHBoxLayout(this);
+    noteSharpButtonsLayout->setContentsMargins(0, 0, 0, 0);
+    layout->addLayout(noteSharpButtonsLayout);
 
+    noteButtonsLayout = new QHBoxLayout(this);
+    noteButtonsLayout->setContentsMargins(0, 0, 0, 0);
+    layout->addLayout(noteButtonsLayout);
+
+    noteC = new MyQCheckBox("C");
+    noteD = new MyQCheckBox("D");
+    noteE = new MyQCheckBox("E");
+    noteF = new MyQCheckBox("F");
+    noteG = new MyQCheckBox("G");
+    noteA = new MyQCheckBox("A");
+    noteB = new MyQCheckBox("B");
+
+    noteCSharp = new MyQCheckBox("C#");
+    noteDSharp = new MyQCheckBox("D#");
+    noteFSharp = new MyQCheckBox("F#");
+    noteGSharp = new MyQCheckBox("G#");
+    noteASharp = new MyQCheckBox("A#");
+
+    // play only one note at time maybe there should be chords button ;)
+    notesButtonGroup = new QButtonGroup(this);
+
+    notesButtonGroup->addButton(noteC);
+    noteC->setChecked(true);
+    notesButtonGroup->addButton(noteD);
+    notesButtonGroup->addButton(noteE);
+    notesButtonGroup->addButton(noteF);
+    notesButtonGroup->addButton(noteG);
+    notesButtonGroup->addButton(noteA);
+    notesButtonGroup->addButton(noteB);
+
+    notesButtonGroup->addButton(noteCSharp);
+    notesButtonGroup->addButton(noteDSharp);
+    notesButtonGroup->addButton(noteFSharp);
+    notesButtonGroup->addButton(noteGSharp);
+    notesButtonGroup->addButton(noteASharp);
+
+    // set id's
+    notesButtonGroup->setId(noteC, 0);
+    notesButtonGroup->setId(noteCSharp, 1);
+    notesButtonGroup->setId(noteD, 2);
+    notesButtonGroup->setId(noteDSharp, 3);
+    notesButtonGroup->setId(noteE, 4);
+    notesButtonGroup->setId(noteF, 5);
+    notesButtonGroup->setId(noteFSharp, 6);
+    notesButtonGroup->setId(noteG, 7);
+    notesButtonGroup->setId(noteGSharp, 8);
+    notesButtonGroup->setId(noteA, 9);
+    notesButtonGroup->setId(noteASharp, 10);
+    notesButtonGroup->setId(noteB, 11);
+
+    noteButtonsLayout->addWidget(noteC);
+    noteButtonsLayout->addWidget(noteD);
+    noteButtonsLayout->addWidget(noteE);
+    noteButtonsLayout->addWidget(noteF);
+    noteButtonsLayout->addWidget(noteG);
+    noteButtonsLayout->addWidget(noteA);
+    noteButtonsLayout->addWidget(noteB);
+
+    noteSharpButtonsLayout->addWidget(noteCSharp);
+    noteSharpButtonsLayout->addWidget(noteDSharp);
+    noteSharpButtonsLayout->addWidget(noteFSharp);
+    noteSharpButtonsLayout->addWidget(noteGSharp);
+    noteSharpButtonsLayout->addWidget(noteASharp);
+
+    presetDemoInstrument = createIllegalInstrument();
 
     connect(tree,SIGNAL(activated(const QModelIndex &)),this,SLOT(UsePreset(const QModelIndex &)));
     connect(tree,SIGNAL(pressed(const QModelIndex &)),this,SLOT(PlayPreset(const QModelIndex &)));
@@ -266,6 +335,8 @@ class PresetBrowser : public QWidget
     void StopPreset(const QModelIndex & index);
     void SetFilter();
 
+  protected:
+    int selectedNote();
   private:
     QLabel* title;
     FocusSnifferQLineEdit * filterEdit;
@@ -273,11 +344,29 @@ class PresetBrowser : public QWidget
     BrowserQSortFilterProxyModel filterModel;
 
     QVBoxLayout *layout;
+    QHBoxLayout *noteButtonsLayout;
+    QHBoxLayout *noteSharpButtonsLayout;
 
     FocusSnifferQTreeView *tree;
     instrument_t presetDemoInstrument;
     int playnote_id = -1;
+
     QString presetFolder;
+    QButtonGroup *notesButtonGroup;
+
+    MyQCheckBox *noteC;
+    MyQCheckBox *noteD;
+    MyQCheckBox *noteE;
+    MyQCheckBox *noteF;
+    MyQCheckBox *noteG;
+    MyQCheckBox *noteA;
+    MyQCheckBox *noteB;
+
+    MyQCheckBox *noteCSharp;
+    MyQCheckBox *noteDSharp;
+    MyQCheckBox *noteFSharp;
+    MyQCheckBox *noteGSharp;
+    MyQCheckBox *noteASharp;
 };
 
 void PresetBrowser::SetFilter() {
@@ -316,6 +405,13 @@ void PresetBrowser::UsePreset(const QModelIndex & index){
     setInstrumentName(fileName.toStdString().c_str(), ins); // set name to preset file name
     //showInstrumentGui(ins, gui_getEditorGui(), false); // show instrument gui
   }
+}
+
+int PresetBrowser::selectedNote() {
+  int note = notesButtonGroup->checkedId();
+  if (note < 0)
+    note = 0;
+  return note;   
 }
 
 void PresetBrowser::PlayPreset(const QModelIndex & index){
@@ -357,7 +453,7 @@ void PresetBrowser::PlayPreset(const QModelIndex & index){
     //qDebug() << "connect preset instrument ";
     connectAudioInstrumentToMainPipe(presetDemoInstrument);
 
-    int notenum = root->keyoct + 24; // default is 36 C2 
+    int notenum = root->keyoct + 24 + selectedNote(); // default is 36 C2 
     if(notenum>=0 && notenum<127)
       playnote_id = playNote(notenum, 120, 0, 0, presetDemoInstrument); // startuje granie nuty
   }

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -411,7 +411,6 @@ void setPresetBrowserRootFolder(const QString &folder) {
 void showHidePresetBrowser(void){
   if (g_presetbrowser_widget_frame)
     g_presetbrowser_widget_frame->setVisible(!g_presetbrowser_widget_frame->isVisible());
-  //setPresetBrowserRootFolder("/home/and3md/akimaze/Radium/Presets");
 }
 
 

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -480,6 +480,11 @@ void showHidePresetBrowser(void){
     g_presetbrowser_widget_frame->setVisible(!g_presetbrowser_widget_frame->isVisible());
 }
 
+void deletePresetBrowserInstrument(void){
+  if (g_presetbrowser_widget) {
+    dynamic_cast<PresetBrowser *>(g_presetbrowser_widget)->deletePresetDemoInstrument();
+  }
+}
 
 #include "mQt_PresetBrowser.cpp"
 

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -402,7 +402,8 @@ void PresetBrowser::playPreset(const QModelIndex & index){
                   qDebug() << "the same instrument, changing only state";
                   PLUGIN_recreate_from_state(plugin, pluginState, false);
 
-                  // wait for lading plugin state
+                  // wait for loading plugin state
+                  // TODO: Find a better solution
                   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
                   playSelectedNote();

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -1,0 +1,401 @@
+/* Copyright 2012 Kjetil S. Matheussen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
+
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
+
+
+
+
+#include <QSpinBox>
+
+#include <qstring.h>
+#include <qlineedit.h>
+#include <qsplitter.h>
+#include <qevent.h>
+#include <qtreeview.h>
+#include <qlistwidget.h>
+#include <QString>
+
+#define INCLUDE_SNDFILE_OPEN_FUNCTIONS 1
+#include "../common/nsmtracker.h"
+
+#include "../common/hashmap_proc.h"
+#include "../common/undo.h"
+#include "../common/player_proc.h"
+//#include "../mixergui/undo_chip_addremove_proc.h"
+#include "../mixergui/undo_mixer_connections_proc.h"
+#include "undo_instruments_widget_proc.h"
+//#include "../common/undo_patchlist_proc.h"
+#include "../common/undo_tracks_proc.h"
+#include "../common/visual_proc.h"
+#include "../common/settings_proc.h"
+#include "../audio/audio_instrument_proc.h"
+#include "../audio/Presets_proc.h"
+#include "../midi/midi_instrument.h"
+#include "../midi/midi_instrument_proc.h"
+#include "../midi/midi_i_input_proc.h"
+#include "../midi/OS_midigfx_proc.h"
+#include "../midi/OS_midi_proc.h"
+
+#include "Qt_MyQSlider.h"
+#include "Qt_MyQLabel.h"
+#include "Qt_MyQCheckBox.h"
+#include "Qt_MyQButton.h"
+#include "Qt_MyQSpinBox.h"
+
+#include "../mixergui/QM_MixerWidget.h"
+#include "../audio/SoundPluginRegistry_proc.h"
+#include "../audio/Mixer_proc.h"
+
+#include "../api/api_gui_proc.h"
+#include "../api/api_proc.h"
+
+#include "Qt_colors_proc.h"
+
+
+#include "Qt_instruments_proc.h"
+
+
+extern QApplication *qapplication;
+
+
+
+#include "FocusSniffers.h"
+
+#include "EditorWidget.h"
+#include "../GTK/GTK_visual_proc.h"
+#include "../OpenGL/Widget_proc.h"
+#include <QTreeView>
+#include <QFileSystemModel>
+#include <QSortFilterProxyModel>
+#include <QVBoxLayout>
+#include <QDebug>
+#include "../api/api_common_proc.h"
+
+#include <string>
+#include <fstream>
+
+QWidget *g_presetbrowser_widget = nullptr;
+static radium::KeyboardFocusFrame *g_presetbrowser_widget_frame;
+
+
+class BrowserQSortFilterProxyModel: public QSortFilterProxyModel
+{
+  protected:
+  bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
+  {
+    QString word = filterText;
+    QStringList words = filterText.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+    QString currIndexData = sourceModel()->data(source_parent, (int)QFileSystemModel::FilePathRole).toString();
+    if (currIndexData == "")
+      return true;
+
+    //QModelIndex index0 = sourceModel()->index(sourceRow, 0, sourceParent);
+    qDebug() << "------------------------------------------------------------------------";
+    /*qDebug() << "filtr: " + sourceModel()->data(source_parent, (int)QFileSystemModel::FilePathRole).toString();
+    QString currIndexData = sourceModel()->data(source_parent, (int)QFileSystemModel::FilePathRole).toString(); 
+
+    if (currIndexData == "") {
+      qDebug() << "true";
+      return true;
+    }
+
+    if (presetFolder.startsWith(currIndexData))
+    {
+      qDebug() << "true";
+      return true;
+    }
+
+    if (currIndexData == presetFolder)
+    {
+      qDebug() << "true";
+      return true;
+    }*/
+
+    /*
+    if (currIndexData.contains(presetFolder, Qt::CaseInsensitive)) {
+      if (currIndexData.contains(word, Qt::CaseInsensitive))
+      {
+          qDebug() << "true";
+          return true;
+      }
+      // check childrens
+            
+    }*/
+
+    // https://stackoverflow.com/questions/250890/using-qsortfilterproxymodel-with-a-tree-model
+    // get source-model index for current row
+    QModelIndex source_index = sourceModel()->index(source_row, 0, source_parent);
+
+    // check current index itself :
+    if( source_index.isValid() ) {
+      QString key = sourceModel()->data(source_index, (int)QFileSystemModel::FilePathRole).toString();
+      qDebug() << "key: " + key;
+
+      if (presetFolder.startsWith(key))
+        return true;
+
+      if (key.startsWith(presetFolder)) {
+        // check words
+        bool containsAll = true;
+        for (int i = 0 ; i < words.size() ; i++)
+        {
+          if (!key.contains(words.at(i), Qt::CaseInsensitive)) {
+            containsAll = false;
+            break;
+          }
+        }
+        if (containsAll)
+          return true;
+      }
+
+      // if any of children matches the filter, then current index matches the filter as well
+      sourceModel()->fetchMore(source_index);
+      qDebug() << "childs start: " + key;
+      int nb = sourceModel()->rowCount(source_index);
+      qDebug() << "rows count " << nb;
+      for ( int i=0; i<nb; ++i ) {
+        if ( filterAcceptsRow(i, source_index) ) {
+          qDebug() << "childs stop: " + key;
+          return true ;
+        }
+      }
+      qDebug() << "childs stop: " + key;
+    }
+    else
+      qDebug() << "something goes wrong -------------------------- ";
+
+
+    qDebug() << "false";
+    return false;
+  }
+
+  public:
+  QString presetFolder;
+  QString filterText;
+
+  void setPresetFolder(const QString &pFolder)
+  {
+    presetFolder = pFolder;
+    invalidateFilter();
+  }
+
+  void setFilter(const QString &filter)
+  {
+    this->filterText = filter;
+    invalidateFilter();
+  }
+
+};
+
+
+class PresetBrowser : public QWidget
+{
+  Q_OBJECT;
+
+  public:
+  PresetBrowser(QWidget *parent=NULL): QWidget(parent) {
+    layout = new QVBoxLayout(this);
+    layout->setSpacing(1);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setObjectName(QString::fromUtf8("vLayout"));
+
+    title = new QLabel("Presets", this);
+    layout->addWidget(title);
+
+    presetFolder = "/home/and3md/akimaze/Radium/Presets";
+
+    model.setRootPath(presetFolder);
+    //filterModel.setRecursiveFilteringEnabled(true);
+    filterModel.setSourceModel(&model);
+    filterModel.setFilterRole((int)QFileSystemModel::FilePathRole);
+    filterModel.setPresetFolder(presetFolder);
+
+    tree = new FocusSnifferQTreeView(this);
+    tree->setModel(&filterModel);
+    tree->setRootIndex(filterModel.mapFromSource(model.index(presetFolder)));
+    //tree->setRootIndex(filterModel.mapFromSource(model.index("")));
+    tree->hideColumn(1);
+    tree->hideColumn(2);
+    tree->hideColumn(3);
+    //tree->setHeaderHidden(true);
+    layout->addWidget(tree);
+
+    filterEdit = new FocusSnifferQLineEdit(this);
+    layout->addWidget(filterEdit);
+
+    presetDemoInstrument = createIllegalInstrument();
+
+
+    connect(tree,SIGNAL(activated(const QModelIndex &)),this,SLOT(UsePreset(const QModelIndex &)));
+    connect(tree,SIGNAL(pressed(const QModelIndex &)),this,SLOT(PlayPreset(const QModelIndex &)));
+    connect(tree,SIGNAL(clicked(const QModelIndex &)),this,SLOT(StopPreset(const QModelIndex &)));
+
+    connect(filterEdit,SIGNAL(editingFinished()),this,SLOT(SetFilter()));
+
+    // https://stackoverflow.com/questions/54930898/how-to-always-expand-items-in-qtreeview
+    connect(tree->model(), &QAbstractItemModel::rowsInserted,
+      [this](const QModelIndex &parent, int first, int last)
+      {
+        // New rows have been added to parent.  Make sure parent is fully expanded.
+        tree->expandRecursively(parent);
+      });
+
+  }
+
+  virtual ~PresetBrowser() {};
+
+  public slots:
+    void UsePreset(const QModelIndex & index);
+    void PlayPreset(const QModelIndex & index);
+    void StopPreset(const QModelIndex & index);
+    void SetFilter();
+
+  private:
+    QLabel* title;
+    FocusSnifferQLineEdit * filterEdit;
+    QFileSystemModel model;
+    BrowserQSortFilterProxyModel filterModel;
+
+    QVBoxLayout *layout;
+
+    FocusSnifferQTreeView *tree;
+    instrument_t presetDemoInstrument;
+    int playnote_id = -1;
+    QString presetFolder;
+};
+
+void PresetBrowser::SetFilter() {
+    filterModel.setFilter(filterEdit->text());
+}
+
+
+void PresetBrowser::UsePreset(const QModelIndex & index){
+  qDebug() << "activation";
+  qDebug() << "file path" + index.data(QFileSystemModel::FilePathRole).toString();
+  QString filePath = index.data(QFileSystemModel::FilePathRole).toString();
+  QString fileName = index.data(QFileSystemModel::FileNameRole).toString();
+
+  QFile ff(filePath);
+  QFileInfo fileInfo(ff);
+  if (fileInfo.exists() && fileInfo.isFile()){
+    QString fileName = fileInfo.baseName();
+    qDebug() << "dziłamy" << fileName;
+    /*ff.open(QIODevice::ReadOnly);
+    QString s;
+    QTextStream s1(&ff);
+    s.append(s1.readAll());
+    //qDebug() << s;
+    QByteArray ba = str1.toLocal8Bit();
+      const char *desc = ba.data();
+    int64_t patch_id = createAudioInstrumentFromDescription(desc, NULL, 1, 1);*/
+
+    //createAudioInstrumentFromPreset(filePath, "aha", 1, 1, true);
+    //PRESET_load(make_filepath(filePath), "aha", true, true, getCurrMixerSlotX(), getCurrMixerSlotY());
+    //createAudioInstrumentFromPreset(make_filepath(filePath), "", getCurrMixerSlotX(), getCurrMixerSlotY(), true);
+    instrument_t ins = createAudioInstrumentFromPreset(make_filepath(filePath), "", 0, 0, true); // create instrument from preset
+
+    setInstrumentForTrack(ins, currentTrack(currentBlock(0), 0), currentBlock(0),0); // add instrument to current track
+    connectAudioInstrumentToMainPipe(ins);
+    autopositionInstrument(ins);
+    setInstrumentName(fileName.toStdString().c_str(), ins); // set name to preset file name
+    //showInstrumentGui(ins, gui_getEditorGui(), false); // show instrument gui
+  }
+}
+
+void PresetBrowser::PlayPreset(const QModelIndex & index){
+  startIgnoringUndo();
+  if (playnote_id >= 0 && isLegalInstrument(presetDemoInstrument))
+  {
+    stopNote(playnote_id, 0, presetDemoInstrument);
+    playnote_id = -1;
+    //qDebug() << "finish preset play 1";
+  }
+
+  if (isLegalInstrument(presetDemoInstrument))
+  {
+    instrument_t i = presetDemoInstrument;
+    presetDemoInstrument = createIllegalInstrument();
+    deleteAudioConnection(i, getMainPipeInstrument());
+    deleteInstrument(i);
+    //qDebug() << "delete preset 2";
+  }
+
+  QString filePath = index.data(QFileSystemModel::FilePathRole).toString();
+  QFile ff(filePath);
+  QFileInfo fileInfo(ff);
+  if (fileInfo.exists() && fileInfo.isFile()){
+    //qDebug() << "create preset demo instrument";
+    presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false);
+
+    /*
+    std::string line,text;
+    std::ifstream in("test.txt");
+    while(std::getline(in, line)) {
+      text += line + "\n";
+    }
+            
+    const char* data = text.c_str();
+    requestLoadInstrumentPreset(presetDemoInstrument, data, gui_getEditorGui());
+    */
+
+    //qDebug() << "connect preset instrument ";
+    connectAudioInstrumentToMainPipe(presetDemoInstrument);
+
+    int notenum = root->keyoct + 24; // default is 36 C2 
+    if(notenum>=0 && notenum<127)
+      playnote_id = playNote(notenum, 120, 0, 0, presetDemoInstrument); // startuje granie nuty
+  }
+  stopIgnoringUndo();
+}
+
+
+void PresetBrowser::StopPreset(const QModelIndex & index){
+  startIgnoringUndo();
+  if (playnote_id >= 0 && isLegalInstrument(presetDemoInstrument)){
+    stopNote(playnote_id, 0, presetDemoInstrument);
+    playnote_id = -1;
+    //qDebug() << "finished 1";
+  }
+  if (isLegalInstrument(presetDemoInstrument))
+  {
+    instrument_t i = presetDemoInstrument;
+    presetDemoInstrument = createIllegalInstrument();
+    deleteAudioConnection(i, getMainPipeInstrument());
+    deleteInstrument(i);
+    //qDebug() << "delete 1";
+  }
+  stopIgnoringUndo();
+}
+
+
+QWidget *createPresetBrowserWidget() {
+  //g_presetbrowser_widget_frame = new radium::KeyboardFocusFrame(g_main_window, radium::KeyboardFocusFrameType::BROWSER, true);
+  g_presetbrowser_widget_frame = new radium::KeyboardFocusFrame(g_main_window, radium::KeyboardFocusFrameType::EDITOR, true);
+  g_presetbrowser_widget = new PresetBrowser(g_presetbrowser_widget_frame);
+  g_presetbrowser_widget_frame->layout()->addWidget(g_presetbrowser_widget);
+
+  return g_presetbrowser_widget_frame;
+}
+
+QWidget *getPresetBrowserWidget(void){
+  return g_presetbrowser_widget;
+}
+
+#include "mQt_PresetBrowser.cpp"
+

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -107,38 +107,7 @@ class BrowserQSortFilterProxyModel: public QSortFilterProxyModel
     if (currIndexData == "")
       return true;
 
-    //QModelIndex index0 = sourceModel()->index(sourceRow, 0, sourceParent);
-    qDebug() << "------------------------------------------------------------------------";
-    /*qDebug() << "filtr: " + sourceModel()->data(source_parent, (int)QFileSystemModel::FilePathRole).toString();
-    QString currIndexData = sourceModel()->data(source_parent, (int)QFileSystemModel::FilePathRole).toString(); 
-
-    if (currIndexData == "") {
-      qDebug() << "true";
-      return true;
-    }
-
-    if (presetFolder.startsWith(currIndexData))
-    {
-      qDebug() << "true";
-      return true;
-    }
-
-    if (currIndexData == presetFolder)
-    {
-      qDebug() << "true";
-      return true;
-    }*/
-
-    /*
-    if (currIndexData.contains(presetFolder, Qt::CaseInsensitive)) {
-      if (currIndexData.contains(word, Qt::CaseInsensitive))
-      {
-          qDebug() << "true";
-          return true;
-      }
-      // check childrens
-            
-    }*/
+    // qDebug() << "------------------------------------------------------------------------";
 
     // https://stackoverflow.com/questions/250890/using-qsortfilterproxymodel-with-a-tree-model
     // get source-model index for current row
@@ -147,7 +116,6 @@ class BrowserQSortFilterProxyModel: public QSortFilterProxyModel
     // check current index itself :
     if( source_index.isValid() ) {
       QString key = sourceModel()->data(source_index, (int)QFileSystemModel::FilePathRole).toString();
-      qDebug() << "key: " + key;
 
       if (presetFolder.startsWith(key))
         return true;
@@ -168,22 +136,16 @@ class BrowserQSortFilterProxyModel: public QSortFilterProxyModel
 
       // if any of children matches the filter, then current index matches the filter as well
       sourceModel()->fetchMore(source_index);
-      qDebug() << "childs start: " + key;
       int nb = sourceModel()->rowCount(source_index);
-      qDebug() << "rows count " << nb;
-      for ( int i=0; i<nb; ++i ) {
+      for ( int i = 0; i < nb; ++i ) {
         if ( filterAcceptsRow(i, source_index) ) {
-          qDebug() << "childs stop: " + key;
           return true ;
         }
       }
-      qDebug() << "childs stop: " + key;
     }
     else
       qDebug() << "something goes wrong -------------------------- ";
 
-
-    qDebug() << "false";
     return false;
   }
 
@@ -375,8 +337,8 @@ void PresetBrowser::SetFilter() {
 
 
 void PresetBrowser::UsePreset(const QModelIndex & index){
-  qDebug() << "activation";
-  qDebug() << "file path" + index.data(QFileSystemModel::FilePathRole).toString();
+  // qDebug() << "activation";
+  // qDebug() << "file path" + index.data(QFileSystemModel::FilePathRole).toString();
   QString filePath = index.data(QFileSystemModel::FilePathRole).toString();
   QString fileName = index.data(QFileSystemModel::FileNameRole).toString();
 
@@ -384,19 +346,6 @@ void PresetBrowser::UsePreset(const QModelIndex & index){
   QFileInfo fileInfo(ff);
   if (fileInfo.exists() && fileInfo.isFile()){
     QString fileName = fileInfo.baseName();
-    qDebug() << "dziłamy" << fileName;
-    /*ff.open(QIODevice::ReadOnly);
-    QString s;
-    QTextStream s1(&ff);
-    s.append(s1.readAll());
-    //qDebug() << s;
-    QByteArray ba = str1.toLocal8Bit();
-      const char *desc = ba.data();
-    int64_t patch_id = createAudioInstrumentFromDescription(desc, NULL, 1, 1);*/
-
-    //createAudioInstrumentFromPreset(filePath, "aha", 1, 1, true);
-    //PRESET_load(make_filepath(filePath), "aha", true, true, getCurrMixerSlotX(), getCurrMixerSlotY());
-    //createAudioInstrumentFromPreset(make_filepath(filePath), "", getCurrMixerSlotX(), getCurrMixerSlotY(), true);
     instrument_t ins = createAudioInstrumentFromPreset(make_filepath(filePath), "", 0, 0, true); // create instrument from preset
 
     setInstrumentForTrack(ins, currentTrack(currentBlock(0), 0), currentBlock(0),0); // add instrument to current track
@@ -438,17 +387,6 @@ void PresetBrowser::PlayPreset(const QModelIndex & index){
   if (fileInfo.exists() && fileInfo.isFile()){
     //qDebug() << "create preset demo instrument";
     presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false);
-
-    /*
-    std::string line,text;
-    std::ifstream in("test.txt");
-    while(std::getline(in, line)) {
-      text += line + "\n";
-    }
-            
-    const char* data = text.c_str();
-    requestLoadInstrumentPreset(presetDemoInstrument, data, gui_getEditorGui());
-    */
 
     //qDebug() << "connect preset instrument ";
     connectAudioInstrumentToMainPipe(presetDemoInstrument);

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -321,7 +321,7 @@ void PresetBrowser::usePreset(const QModelIndex & index){
   QFileInfo fileInfo(ff);
   if (fileInfo.exists() && fileInfo.isFile()){
     QString fileName = fileInfo.baseName();
-    instrument_t ins = createAudioInstrumentFromPreset(make_filepath(filePath), "", 0, 0, true); // create instrument from preset
+    instrument_t ins = createAudioInstrumentFromPreset(make_filepath(filePath), "", 0, 0, true, true); // create instrument from preset
 
     setInstrumentForTrack(ins, currentTrack(currentBlock(0), 0), currentBlock(0),0); // add instrument to current track
     connectAudioInstrumentToMainPipe(ins);
@@ -425,7 +425,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
 
     // full create new instrument
     //qDebug() << "creating new instrument";
-    presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false);
+    presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false, false);
     setInstrumentName("Preset Preview", presetDemoInstrument);
 
     //qDebug() << "connect preset instrument ";

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -372,6 +372,9 @@ int PresetBrowser::selectedNote() {
 }
 
 void PresetBrowser::PlayPreset(const QModelIndex & index){
+  if (QGuiApplication::mouseButtons() != Qt::LeftButton)
+    return;
+
   startIgnoringUndo();
   if (playnote_id >= 0 && isLegalInstrument(presetDemoInstrument))
   {

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -152,7 +152,7 @@ class PresetBrowser : public QWidget
     filterModel.setFilterRole((int)QFileSystemModel::FilePathRole);
     filterModel.setPresetFolder(presetFolder);
 
-    tree = new FocusSnifferQTreeView(this);
+    tree = new QTreeView(this);
     tree->setModel(&filterModel);
     tree->setRootIndex(filterModel.mapFromSource(model.index(presetFolder)));
     tree->hideColumn(1);
@@ -278,7 +278,7 @@ class PresetBrowser : public QWidget
     QHBoxLayout *noteButtonsLayout;
     QHBoxLayout *noteSharpButtonsLayout;
 
-    FocusSnifferQTreeView *tree;
+    QTreeView *tree;
     instrument_t presetDemoInstrument;
     QString lastPlayedPresetPath;
     int playnote_id = -1;

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -397,5 +397,10 @@ QWidget *getPresetBrowserWidget(void){
   return g_presetbrowser_widget;
 }
 
+QWidget *getPresetBrowserWidgetFrame(void){
+  return g_presetbrowser_widget_frame;
+}
+
+
 #include "mQt_PresetBrowser.cpp"
 

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -430,6 +430,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
     // full create new instrument
     qDebug() << "creating new instrument";
     presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false);
+    setInstrumentName("Preset Preview", presetDemoInstrument);
 
     //qDebug() << "connect preset instrument ";
     connectAudioInstrumentToMainPipe(presetDemoInstrument);

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -250,7 +250,9 @@ class PresetBrowser : public QWidget
       });
   }
 
-  virtual ~PresetBrowser() {};
+  virtual ~PresetBrowser() {
+    deletePresetDemoInstrument();
+  };
 
   public slots:
     void usePreset(const QModelIndex & index);
@@ -259,6 +261,8 @@ class PresetBrowser : public QWidget
     void setFilter();
 
     void setPresetFolder(const QString &presetRootFolder);
+
+    void deletePresetDemoInstrument();
 
   protected:
     int selectedNote();
@@ -297,6 +301,14 @@ class PresetBrowser : public QWidget
     MyQCheckBox *noteASharp;
 };
 
+void PresetBrowser::deletePresetDemoInstrument() {
+  if (isLegalInstrument(presetDemoInstrument)) {
+    instrument_t i = presetDemoInstrument;
+    presetDemoInstrument = createIllegalInstrument();
+    deleteAudioConnection(i, getMainPipeInstrument());
+    deleteInstrument(i);
+  }
+}
 
 void PresetBrowser::setPresetFolder(const QString &presetRootFolder) {
   presetFolder = presetRootFolder;
@@ -417,10 +429,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
         }
       }
       // when trying to modify instrument fail delete it
-      instrument_t i = presetDemoInstrument;
-      presetDemoInstrument = createIllegalInstrument();
-      deleteAudioConnection(i, getMainPipeInstrument());
-      deleteInstrument(i);
+      deletePresetDemoInstrument();
     }
 
     // full create new instrument

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -14,70 +14,22 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
+#include "Qt_PresetBrowser.h"
+
 #define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
-
-#include <QSpinBox>
-
-#include <qstring.h>
-#include <qlineedit.h>
-#include <qsplitter.h>
-#include <qevent.h>
-#include <qtreeview.h>
-#include <qlistwidget.h>
-#include <QString>
-
 #define INCLUDE_SNDFILE_OPEN_FUNCTIONS 1
 #include "../common/nsmtracker.h"
-
-#include "../common/hashmap_proc.h"
-#include "../common/undo.h"
-#include "../common/player_proc.h"
-//#include "../mixergui/undo_chip_addremove_proc.h"
-#include "../mixergui/undo_mixer_connections_proc.h"
-#include "undo_instruments_widget_proc.h"
-//#include "../common/undo_patchlist_proc.h"
-#include "../common/undo_tracks_proc.h"
-#include "../common/visual_proc.h"
-#include "../common/settings_proc.h"
-#include "../audio/audio_instrument_proc.h"
-#include "../audio/Presets_proc.h"
-#include "../midi/midi_instrument.h"
-#include "../midi/midi_instrument_proc.h"
-#include "../midi/midi_i_input_proc.h"
-#include "../midi/OS_midigfx_proc.h"
-#include "../midi/OS_midi_proc.h"
 
 #include "Qt_MyQSlider.h"
 #include "Qt_MyQLabel.h"
 #include "Qt_MyQCheckBox.h"
 #include "Qt_MyQButton.h"
 #include "Qt_MyQSpinBox.h"
-
-#include "../mixergui/QM_MixerWidget.h"
-#include "../audio/SoundPluginRegistry_proc.h"
-#include "../audio/Mixer_proc.h"
-
-#include "../api/api_gui_proc.h"
-#include "../api/api_proc.h"
-
-
 #include "Qt_colors_proc.h"
-
-
-#include "Qt_instruments_proc.h"
-
-
-extern QApplication *qapplication;
-
-
-
 #include "FocusSniffers.h"
 
-#include "EditorWidget.h"
-#include "../GTK/GTK_visual_proc.h"
-#include "../OpenGL/Widget_proc.h"
 #include <QTreeView>
 #include <QFileSystemModel>
 #include <QSortFilterProxyModel>
@@ -85,10 +37,6 @@ extern QApplication *qapplication;
 #include <QHBoxLayout>
 #include <QDebug>
 #include <QButtonGroup>
-#include "../api/api_common_proc.h"
-
-#include <string>
-#include <fstream>
 
 QWidget *g_presetbrowser_widget = nullptr;
 static radium::KeyboardFocusFrame *g_presetbrowser_widget_frame = nullptr;

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -92,7 +92,7 @@ extern QApplication *qapplication;
 #include <fstream>
 
 QWidget *g_presetbrowser_widget = nullptr;
-static radium::KeyboardFocusFrame *g_presetbrowser_widget_frame;
+static radium::KeyboardFocusFrame *g_presetbrowser_widget_frame = nullptr;
 
 
 class BrowserQSortFilterProxyModel: public QSortFilterProxyModel
@@ -446,6 +446,10 @@ QWidget *getPresetBrowserWidgetFrame(void){
   return g_presetbrowser_widget_frame;
 }
 
+void showHidePresetBrowser(void){
+  if (g_presetbrowser_widget_frame)
+    g_presetbrowser_widget_frame->setVisible(!g_presetbrowser_widget_frame->isVisible());
+}
 
 #include "mQt_PresetBrowser.cpp"
 

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2012 Kjetil S. Matheussen
+/* Copyright 2022 Kjetil S. Matheussen
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -359,7 +359,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
   if (QGuiApplication::mouseButtons() != Qt::LeftButton)
     return;
 
-  startIgnoringUndo();
+  radium::ScopedIgnoreUndo ignore_undo;
   stopPlayingSelectedNote();
 
   QString filePath = index.data(QFileSystemModel::FilePathRole).toString();
@@ -372,7 +372,6 @@ void PresetBrowser::playPreset(const QModelIndex & index){
       //qDebug() << "the same preset";
       if (lastPlayedPresetPath == filePath) {
         playSelectedNote();
-        stopIgnoringUndo();
         return;
       }
 
@@ -409,8 +408,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
                   playSelectedNote();
                   lastPlayedPresetPath = filePath;
 
-                  // TODO: should we delete preset HASH here?  
-                  stopIgnoringUndo();
+                  // HASH is garbage-collected using BDW-GC, no need to delete it 
                   return;
                 }
               }
@@ -418,8 +416,6 @@ void PresetBrowser::playPreset(const QModelIndex & index){
           }
         }
       }
-      // TODO: should we delete preset HASH here?
-
       // when trying to modify instrument fail delete it
       instrument_t i = presetDemoInstrument;
       presetDemoInstrument = createIllegalInstrument();
@@ -437,14 +433,12 @@ void PresetBrowser::playPreset(const QModelIndex & index){
     playSelectedNote();
     lastPlayedPresetPath = filePath;
   }
-  stopIgnoringUndo();
 }
 
 
 void PresetBrowser::stopPreset(const QModelIndex & index){
-  startIgnoringUndo();
+  radium::ScopedIgnoreUndo ignore_undo;
   stopPlayingSelectedNote();
-  stopIgnoringUndo();
 }
 
 

--- a/Qt/Qt_PresetBrowser.cpp
+++ b/Qt/Qt_PresetBrowser.cpp
@@ -369,7 +369,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
 
     if (isLegalInstrument(presetDemoInstrument)) {
       // the same preset again only play note
-      qDebug() << "the same preset";
+      //qDebug() << "the same preset";
       if (lastPlayedPresetPath == filePath) {
         playSelectedNote();
         stopIgnoringUndo();
@@ -399,7 +399,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
                 if ((strcmp(plugin->type->type_name, pluginType) == 0) && (strcmp(plugin->type->name, pluginName) == 0))
                 {
                   // the same instrument only reload plugin state
-                  qDebug() << "the same instrument, changing only state";
+                  //qDebug() << "the same instrument, changing only state";
                   PLUGIN_recreate_from_state(plugin, pluginState, false);
 
                   // wait for loading plugin state
@@ -428,7 +428,7 @@ void PresetBrowser::playPreset(const QModelIndex & index){
     }
 
     // full create new instrument
-    qDebug() << "creating new instrument";
+    //qDebug() << "creating new instrument";
     presetDemoInstrument = createAudioInstrumentFromPreset(make_filepath(filePath), "PresetPlayer", 1, 1, false);
     setInstrumentName("Preset Preview", presetDemoInstrument);
 

--- a/Qt/Qt_PresetBrowser.h
+++ b/Qt/Qt_PresetBrowser.h
@@ -21,5 +21,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 class QWidget;
 QWidget *createPresetBrowserWidget(void);
 QWidget *getPresetBrowserWidget(void);
+QWidget *getPresetBrowserWidgetFrame(void);
 
 #endif

--- a/Qt/Qt_PresetBrowser.h
+++ b/Qt/Qt_PresetBrowser.h
@@ -23,4 +23,6 @@ QWidget *createPresetBrowserWidget(void);
 QWidget *getPresetBrowserWidget(void);
 QWidget *getPresetBrowserWidgetFrame(void);
 
+void showHidePresetBrowser(void);
+
 #endif

--- a/Qt/Qt_PresetBrowser.h
+++ b/Qt/Qt_PresetBrowser.h
@@ -19,10 +19,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
 
 
 class QWidget;
-QWidget *createPresetBrowserWidget(void);
+class QString;
+
+QWidget *createPresetBrowserWidget(const QString &presetRootFolder);
 QWidget *getPresetBrowserWidget(void);
 QWidget *getPresetBrowserWidgetFrame(void);
 
 void showHidePresetBrowser(void);
+void setPresetBrowserRootFolder(const QString &folder);
 
 #endif

--- a/Qt/Qt_PresetBrowser.h
+++ b/Qt/Qt_PresetBrowser.h
@@ -1,0 +1,25 @@
+/* Copyright 2012 Kjetil S. Matheussen
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA. */
+
+#ifndef QT_PRESETBROWSER_H
+#define QT_PRESETBROWSER_H
+
+
+class QWidget;
+QWidget *createPresetBrowserWidget(void);
+QWidget *getPresetBrowserWidget(void);
+
+#endif

--- a/Qt/Qt_PresetBrowser.h
+++ b/Qt/Qt_PresetBrowser.h
@@ -25,7 +25,6 @@ QWidget *createPresetBrowserWidget(const QString &presetRootFolder);
 QWidget *getPresetBrowserWidget(void);
 QWidget *getPresetBrowserWidgetFrame(void);
 
-void showHidePresetBrowser(void);
 void setPresetBrowserRootFolder(const QString &folder);
 
 #endif

--- a/Qt/Qt_preferences_callbacks.cpp
+++ b/Qt/Qt_preferences_callbacks.cpp
@@ -719,6 +719,11 @@ class Preferences : public RememberGeometryQDialog, public Ui::Preferences {
         showBarsAndBeats->setChecked(true);
     }
 
+    // Preset Browser
+    {
+      presetBrowserRootFolder->setText(SETTINGS_read_qstring("preset_root_folder", QDir::homePath() + QString::fromUtf8("/Radium Presets")));
+    }
+
     // Sequencer
     {
 

--- a/Qt/qt4_preferences.ui
+++ b/Qt/qt4_preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1099</width>
-    <height>582</height>
+    <height>589</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>5</number>
+      <number>2</number>
      </property>
      <property name="elideMode">
       <enum>Qt::ElideNone</enum>
@@ -3126,6 +3126,48 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="Browser">
+      <property name="focusPolicy">
+       <enum>Qt::NoFocus</enum>
+      </property>
+      <attribute name="title">
+       <string>Preset Browser</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_34">
+       <item>
+        <widget class="QGroupBox" name="groupBox_26">
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_33">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Preset folder</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="presetBrowserRootFolder"/>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_37">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="sequencer">
       <attribute name="title">
        <string>Sequencer</string>
@@ -5902,8 +5944,8 @@ such as Ardour, Bitwig, or another instance of Radium.</string>
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>949</width>
-               <height>247</height>
+               <width>942</width>
+               <height>245</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="midi_input_layout">
@@ -9578,8 +9620,8 @@ or remove anti-aliasing.&lt;/span&gt;&lt;/body&gt;&lt;/html&gt;</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>582</width>
-              <height>265</height>
+              <width>553</width>
+              <height>263</height>
              </rect>
             </property>
             <property name="sizePolicy">

--- a/api/protos.conf
+++ b/api/protos.conf
@@ -535,6 +535,8 @@ void hideEditor
 showHideEditor | int windownum ? -1
 void showHideFocusEditor # same as showHideEditor, but if editor is visible and doesn't have keyboard focus, editor will get keyboard focus instead of hidden.
 
+void showHidePresetBrowser 
+
 void setEditorKeyboardFocus | bool setit ? true
 void setMixerKeyboardFocus | bool setit ? true
 void setSequencerKeyboardFocus | bool setit ? true

--- a/api/protos.conf
+++ b/api/protos.conf
@@ -535,7 +535,8 @@ void hideEditor
 showHideEditor | int windownum ? -1
 void showHideFocusEditor # same as showHideEditor, but if editor is visible and doesn't have keyboard focus, editor will get keyboard focus instead of hidden.
 
-void showHidePresetBrowser 
+void showHidePresetBrowser
+void deletePresetBrowserInstrument 
 
 void setEditorKeyboardFocus | bool setit ? true
 void setMixerKeyboardFocus | bool setit ? true

--- a/audio/Juce_plugins.cpp
+++ b/audio/Juce_plugins.cpp
@@ -2463,8 +2463,8 @@ static void cleanup_plugin_data(SoundPlugin *plugin){
 #endif
       
       // Then schedule deletion in 5 seconds.
-#if 1
-      //delete data->audio_instance;
+#if 0
+      delete data->audio_instance;
       delete data;
 #else
       new DelayDeleteData(data);

--- a/audio/Juce_plugins.cpp
+++ b/audio/Juce_plugins.cpp
@@ -2463,8 +2463,8 @@ static void cleanup_plugin_data(SoundPlugin *plugin){
 #endif
       
       // Then schedule deletion in 5 seconds.
-#if 0
-      delete data->audio_instance;
+#if 1
+      //delete data->audio_instance;
       delete data;
 #else
       new DelayDeleteData(data);

--- a/audio/SoundPlugin.cpp
+++ b/audio/SoundPlugin.cpp
@@ -1491,7 +1491,7 @@ static void add_eud_undo(QVector<EffectUndoData> &s_euds, QHash<instrument_t, QS
       
       struct Patch *patch = PATCH_get_from_id(eud.patch_id);
       
-      if (patch != NULL) {
+      if (patch != NULL && patch->is_visible) {
         //printf("    EUD undo %d: %f\n", eud.effect_num, eud.effect_value);
         ADD_UNDO(AudioEffect_CurrPos2(patch, eud.effect_num, eud.effect_value, AE_ALWAYS_CREATE_SOLO_AND_BYPASS_UNDO));
       }

--- a/bin/menues.conf
+++ b/bin/menues.conf
@@ -62,6 +62,7 @@ Windows
 	Show/Hide Sequencer             | ra.showHideFocusSequencer
 	Show/Hide Instruments		| ra.showHideInstrumentWidget
 	Show/Hide Edit                  | ra.showHideEditWidget
+	Show/Hide Preset Browser	| ra.showHidePresetBrowser	
 	-------------------
 	Set Editor Keyboard focus       | ra.setEditorKeyboardFocus
 	Set Mixer Keyboard focus       | ra.setMixerKeyboardFocus

--- a/common/disk_load.c
+++ b/common/disk_load.c
@@ -340,6 +340,7 @@ static bool Load_CurrPos_org(struct Tracker_Windows *window, filepath_t filename
 	if(isIllegalFilepath(filename))
           goto exit;
 
+        deletePresetBrowserInstrument();
         g_is_loading = true;
 
         


### PR DESCRIPTION
Hi this is the most important feature that I missed the most in Radium, so I tried to implement it.

Now it look s like this:

![image](https://user-images.githubusercontent.com/63190361/169711298-4465caa0-b841-4a41-ae8d-a5d38d0f8918.png)


## How it works

### Searching

In order not to create some tag system etc. I adopted a solution similar to the one in LMMS. Presets can be in any number of subfolders. The search searches through all subfolders and returns results that match not only the file names but the folders as well. For example, if we are looking for `bass`, all files containing the word bass will be displayed, but also all other files that are in a subfolder with the name containing the word `bass`:

![image](https://user-images.githubusercontent.com/63190361/169711362-339fcbdf-5bba-43d2-9b96-a4ed0a9823e7.png)

In my opinion subfolders are better than the tag system - creating presets is much faster when you only have to enter the filename.

### Playing
When you press the left mouse button on the preset a temporary instrument is created and it plays the note selected with the currently checked note button at the bottom of the preset panel. You can change octave by F1, F2 keys. We can also add checkbox to enable/disable this feature. But this feature is essential for me.

Currently only one note is playing but i the feture we can add mode to play chords.

### Creating and adding instrument to current track

Simply double click on preset in the tree to add instrument and assign it to current track. Previous instrument is not deleted. 
Added instrument name is changed to preset file name.

### Showing/hidding preset panel 

I added option in menu, by default its visible.

## Opportunities for the future

We can add tabs on the top to add samples folders and saved blocks to import to project. 

## Configuration

Currently Preset Browser searches `~/Radium Presets` folder. I tried to add configuration in preferences but I don't know how implement saving this path from QLineEdit. I added Preset browser" tab, but in the future (when there will be samples/blocks tabs) its name should change to "Browser" and there will be more content. 

## Other bugs 
I found a bug that makes a deadlock in instrument deleting, see https://github.com/kmatheussen/radium/commit/5cf3bbb30176d53fec8e187ca44e69fe32d9d167. I don't know this is right solution but after that change preset browser preview preset works always. 

## Optimization

To enable preset playback I create an instrument and when the mouse button is up I remove the instrument. It is quite slow, but I think you probably know a better solution. Maybe hidden instrument for preset preview. That's too hard to me to make (I don't know Radium sources so well currently).

## Performance
Currently, I checked the search performance on a small number of presets, so I don't know how it will work on a large number of presets.

## Code
I don't know Radium sources so well currently, so some things may done wrong or not optimal. I tried to write code in your style.

I hope you enjoy this feature. If you want to include it in Radium. Feel free change anything you want.

