### PR TITLE
Fixed export single block (removed asserts).

### DIFF
--- a/common/player_startstop.cpp
+++ b/common/player_startstop.cpp
@@ -311,7 +311,6 @@ static void start_player(int playtype, double abstime, int64_t absabstime, const
     
   } else {
 
-    R_ASSERT(playtype==PLAYBLOCK);
     R_ASSERT(equal_doubles(abstime, 0));
     R_ASSERT(seqtrack==NULL);
     R_ASSERT(seqblock==NULL);

--- a/common/scheduler_seqtracks.c
+++ b/common/scheduler_seqtracks.c
@@ -322,7 +322,6 @@ void start_seqtrack_song_scheduling(const player_start_data_t *startdata, int pl
 struct SeqBlock g_block_seqtrack_seqblock = {0};
 
 void start_seqtrack_block_scheduling(struct Blocks *block, const Place place, int playtype){
-  R_ASSERT(playtype==PLAYBLOCK);
   
   static Place static_place;
 


### PR DESCRIPTION
I didn't find the bounce option so I wanted to use single-block export. But an attempt to export single block ends with an assertion. I've removed assertions and everything seems to be working. Maybe they shouldn't be in those places.

BTW. Is there a way to simple reverse sample on audio sectrack?