### PR TITLE
Add the ability to use the alt key as a horizontal scroll modifier

### DIFF
--- a/Qt/Qt_Main.cpp
+++ b/Qt/Qt_Main.cpp
@@ -3077,6 +3077,13 @@ bool Control2Pressed(void){
 }
 */
 
+Qt::KeyboardModifier HorizontalModifier() {
+  if (SETTINGS_read_bool("alt_as_horizonal_scroll_modifier", false))
+    return Qt::AltModifier;
+  else
+    return Qt::MetaModifier;
+}
+
 bool MetaPressed(void){
 #if defined(FOR_WINDOWS)
   return W_windows_key_down(); // We have to go pretty low-level (WH_KEYBOARD_LL hook) to check if a win key is pressed.
@@ -3086,11 +3093,21 @@ bool MetaPressed(void){
 }
 
 bool HorizontalModifierPressed(Qt::KeyboardModifiers modifiers){
-  return MetaPressed();
+  if (HorizontalModifier() == Qt::MetaModifier)
+    return MetaPressed();
+  else
+    return QApplication::keyboardModifiers() & HorizontalModifier();
 }
 
 bool HorizontalModifierPressed(void){
   return HorizontalModifierPressed(QApplication::keyboardModifiers());
+}
+
+int HorizontalModifierAngleDelta(QWheelEvent *e) {
+  if ( HorizontalModifier()  == Qt::MetaModifier )
+    return e->angleDelta().y();
+  else
+    return e->angleDelta().x();
 }
                                
 bool VerticalModifierPressed(Qt::KeyboardModifiers modifiers){

--- a/Qt/Qt_mixer_widget_callbacks.h
+++ b/Qt/Qt_mixer_widget_callbacks.h
@@ -196,7 +196,7 @@ public:
       
       QScrollBar *scrollbar = horizontalScrollBar();
       if(scrollbar!=NULL){
-        if (e->angleDelta().y() > 0)
+        if (HorizontalModifierAngleDelta(e) > 0)
           scrollbar->setValue(scrollbar->value()+70);
         else
           scrollbar->setValue(scrollbar->value()-70);

--- a/Qt/Qt_preferences_callbacks.cpp
+++ b/Qt/Qt_preferences_callbacks.cpp
@@ -772,6 +772,8 @@ class Preferences : public RememberGeometryQDialog, public Ui::Preferences {
         sequencer_scroll_wheel_starts_stops_playing->setChecked(true);
       else
         sequencer_scroll_wheel_scrolls_up_down->setChecked(true);
+
+      alt_as_horizonal_scroll_modifier->setChecked(SETTINGS_read_bool("alt_as_horizonal_scroll_modifier", false));
     }
 
     // Windows
@@ -1470,6 +1472,11 @@ public slots:
   void on_sequencer_scroll_wheel_starts_stops_playing_toggled(bool val){
     if (_initing==false)
       setSequencerMouseScrollWheelStartsStopsPlaying(val);
+  }
+
+  void on_alt_as_horizonal_scroll_modifier_toggled(bool val){
+    if (_initing==false)
+      SETTINGS_write_bool("alt_as_horizonal_scroll_modifier", val);
   }
   
   // colors

--- a/Qt/Qt_sequencer.cpp
+++ b/Qt/Qt_sequencer.cpp
@@ -921,8 +921,8 @@ static void handle_wheel_event(QWidget *widget, QWheelEvent *e, int x1, int x2, 
     
   } else if (HorizontalModifierPressed(e->modifiers())) {
 
-    SEQUENCER_zoom_or_move_leftright(false, (e->angleDelta().y() > 0) ? 1 : -1);;
-    
+    SEQUENCER_zoom_or_move_leftright(false, (HorizontalModifierAngleDelta(e) > 0) ? 1 : -1);
+
   } else {
 
     bool do_playstop = sequencerMouseScrollWheelStartsStopsPlaying();

--- a/Qt/qt4_preferences.ui
+++ b/Qt/qt4_preferences.ui
@@ -8993,7 +8993,7 @@ Optimization level 5 may cause very long compilation time with no apparent benef
              </property>
             </widget>
            </item>
-           <item row="16" column="0">
+           <item row="17" column="0">
             <spacer name="verticalSpacer_25">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -9543,6 +9543,13 @@ Optimization level 5 may cause very long compilation time with no apparent benef
             <widget class="QCheckBox" name="help_window_is_child_of_main_window">
              <property name="text">
               <string>Manual: Let manual window be a child of the main window (always on top, etc.)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0">
+            <widget class="QCheckBox" name="alt_as_horizonal_scroll_modifier">
+             <property name="text">
+              <string>Use Alt key as a horizontal scroll modifier instead of Windows (Super/Meta) key</string>
              </property>
             </widget>
            </item>

--- a/common/OS_visual_input.h
+++ b/common/OS_visual_input.h
@@ -58,6 +58,7 @@ extern LANGSPEC bool VerticalModifierPressed(void);
 #ifdef USE_QT4
 bool Control2Pressed(Qt::KeyboardModifiers modifiers);
 bool HorizontalModifierPressed(Qt::KeyboardModifiers modifiers);
+int HorizontalModifierAngleDelta(QWheelEvent *e);
 bool VerticalModifierPressed(Qt::KeyboardModifiers modifiers);
 #endif
 


### PR DESCRIPTION
Hi,
This PR partially  fixes https://github.com/kmatheussen/radium/issues/1393. I added an option in preferences to change horizontal scroll modifier from Windows/Meta/Super key to Alt. This fixes the biggest problem on some desktops like Cinnamon that always uses that key to show main menu and makes it unusable. 

I added option to GUI tab currently because that's only one checkbox:

![image](https://github.com/kmatheussen/radium/assets/63190361/7dad6148-f729-4653-befa-39c61ffd28a3)

I didn't find any conflict with current keybindings when alt is used as horizontal scroll modifier.
Windows/Meta key is still the default modifier. 

