### PR TITLE
Automatically add an extension to the preset name if it has not been added manually

### DIFF
--- a/audio/Presets.cpp
+++ b/audio/Presets.cpp
@@ -475,10 +475,11 @@ void PRESET_save(const vector_t *patches, bool save_button_pressed, int64_t pare
   QFileInfo fileInfo(filename);
   QString extension = fileInfo.suffix();
 
-  if (extension.isEmpty()) {
-    if (is_multipreset)
+  if (is_multipreset) {
+    if (extension != "mrec")
       filename += ".mrec";
-    else
+  } else {
+    if (extension != "rec")
       filename += ".rec";
   }
 

--- a/audio/Presets.cpp
+++ b/audio/Presets.cpp
@@ -472,6 +472,16 @@ void PRESET_save(const vector_t *patches, bool save_button_pressed, int64_t pare
   if(filename=="")
     return;
 
+  QFileInfo fileInfo(filename);
+  QString extension = fileInfo.suffix();
+
+  if (extension.isEmpty()) {
+    if (is_multipreset)
+      filename += ".mrec";
+    else
+      filename += ".rec";
+  }
+
   disk_t *file = DISK_open_for_writing(filename);
   
   if(file==NULL){


### PR DESCRIPTION
Fixes https://github.com/kmatheussen/radium/issues/1353