### PR TITLE
Fix configuration.sh

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -22,7 +22,7 @@
 
 # (do some stuff first)
 ORG_PWD=`pwd`
-cd $(dirname $0)
+cd $(dirname ${BASH_SOURCE[0]})
 source helpers.sh
 
 


### PR DESCRIPTION
configuration.sh is sourced from bin/packages/build.sh

When using `source`, `$0` still points to the original script (build.sh). To get the dir of the sourced script (configuration.sh), we need to use `${BASH_SOURCE[0]}`.